### PR TITLE
Require a user login for practitioner routes

### DIFF
--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -2,11 +2,9 @@ import passport from 'passport'
 import flash from 'connect-flash'
 import { Router } from 'express'
 import { Strategy } from 'passport-oauth2'
-// import { VerificationClient, AuthenticatedRequest } from '@ministryofjustice/hmpps-auth-clients'
 import config from '../config'
 import { HmppsUser } from '../interfaces/hmppsUser'
 import generateOauthClientToken from '../utils/clientCredentials'
-// import logger from '../../logger'
 
 passport.serializeUser((user, done) => {
   // Not used but required for Passport
@@ -37,7 +35,6 @@ passport.use(
 
 export default function setupAuthentication() {
   const router = Router()
-  // const tokenVerificationClient = new VerificationClient(config.apis.tokenVerification, logger)
 
   router.use(passport.initialize())
   router.use(passport.session())
@@ -52,7 +49,7 @@ export default function setupAuthentication() {
 
   router.get('/sign-in/callback', (req, res, next) =>
     passport.authenticate('oauth2', {
-      successReturnToOrRedirect: req.session.returnTo || '/',
+      successReturnToOrRedirect: req.session.returnTo || '/practitioners/dashboard',
       failureRedirect: '/autherror',
     })(req, res, next),
   )
@@ -73,14 +70,6 @@ export default function setupAuthentication() {
   router.use('/account-details', (req, res) => {
     res.redirect(`${authUrl}/account-details?${authParameters}`)
   })
-
-  // router.use(async (req, res, next) => {
-  //   if (req.isAuthenticated() && (await tokenVerificationClient.verifyToken(req as unknown as AuthenticatedRequest))) {
-  //     return next()
-  //   }
-  //   req.session.returnTo = req.originalUrl
-  //   return res.redirect('/sign-in')
-  // })
 
   router.use((req, res, next) => {
     res.locals.user = req.user as HmppsUser

--- a/server/routes/practitionersRoutes.ts
+++ b/server/routes/practitionersRoutes.ts
@@ -1,6 +1,11 @@
 import { type RequestHandler, Router } from 'express'
+import { VerificationClient, AuthenticatedRequest } from '@ministryofjustice/hmpps-auth-clients'
 import asyncMiddleware from '../middleware/asyncMiddleware'
+import config from '../config'
 import validateFormData from '../middleware/validateFormData'
+import authorisationMiddleware from '../middleware/authorisationMiddleware'
+import setUpCurrentUser from '../middleware/setUpCurrentUser'
+import logger from '../../logger'
 
 import {
   handleRedirect,
@@ -27,8 +32,23 @@ import {
   frequencySchema,
 } from '../schemas/practitionersSchemas'
 
+
 export default function routes(): Router {
   const router = Router({ mergeParams: true })
+
+  // practitioner routes all require a login
+  const tokenVerificationClient = new VerificationClient(config.apis.tokenVerification, logger)
+  router.use(async (req, res, next) => {
+    if (req.isAuthenticated() && (await tokenVerificationClient.verifyToken(req as unknown as AuthenticatedRequest))) {
+      return next()
+    }
+    req.session.returnTo = req.originalUrl
+    return res.redirect('/sign-in')
+  })
+
+  router.use(authorisationMiddleware())
+  router.use(setUpCurrentUser())
+
   const get = (routePath: string | string[], handler: RequestHandler) => router.get(routePath, asyncMiddleware(handler))
 
   get('/', renderDashboard)


### PR DESCRIPTION
Add the authentication and authorisation middleware to the router for the practitioner routes so an active user session is required to access those pages.

Update the default signin redirect route to the practitioner dashboard.