### PR TITLE
Change content type of snapshot images to image/jpeg

### DIFF
--- a/assets/js/video.js
+++ b/assets/js/video.js
@@ -122,7 +122,7 @@ async function getVideoFrameAtTwoSeconds() {
       } else {
         reject(new Error('Failed to extract frame'))
       }
-    }, 'image/png')
+    }, 'image/jpeg')
   })
   this.videoFrame = frameBlob
 }

--- a/server/controllers/submissionController.ts
+++ b/server/controllers/submissionController.ts
@@ -82,7 +82,7 @@ export const renderVideoRecord: RequestHandler = async (req, res, next) => {
   try {
     const { submissionId } = req.params
     const videoContentType = 'video/mp4'
-    const frameContentType = 'image/png'
+    const frameContentType = 'image/jpeg'
     const promises = [
       esupervisionService.getCheckinVideoUploadLocation(submissionId, videoContentType),
       esupervisionService.getCheckinFrameUploadLocation(submissionId, frameContentType),
@@ -104,10 +104,10 @@ export const renderVideoRecord: RequestHandler = async (req, res, next) => {
     const [referencePhotoUploadUrl, ...snapshotPhotoUploadUrls] = frameUploadLocations.map(location => location.url)
     const referencePhotoUploadResult = await fetch(referencePhotoUploadUrl, {
       method: 'PUT',
-      body: offenderReferencePhoto,
       headers: {
-        'Content-Type': 'image/png',
+        'Content-Type': offenderReferencePhoto.type,
       },
+      body: offenderReferencePhoto,
     })
 
     if (!referencePhotoUploadResult.ok) {


### PR DESCRIPTION
Capture a jpeg image from the video and change the content type of the comparison images to image/jpeg to match the type of the PoP profile photo.

Use the content type of profile photo blob when uploading to S3 for rekognition.