### PR TITLE
Add model types for survey responses

### DIFF
--- a/server/controllers/practitionersController.ts
+++ b/server/controllers/practitionersController.ts
@@ -117,12 +117,11 @@ export const renderCreateInvite: RequestHandler = async (req, res, next) => {
 export const handleCreateInvite: RequestHandler = async (req, res, next) => {
   try {
     const { offenderId } = req.params
-    const { dueDate, questions } = req.body
+    const { dueDate } = req.body
 
     const data = {
       practitioner: res.locals.user.userId,
       offender: offenderId,
-      questions,
       dueDate,
     }
 

--- a/server/controllers/practitionersController.ts
+++ b/server/controllers/practitionersController.ts
@@ -73,13 +73,6 @@ export const renderCheckInDetail: RequestHandler = async (req, res, next) => {
   try {
     const { checkInId } = req.params
     const checkIn = await esupervisionService.getCheckin(checkInId)
-
-    try {
-      checkIn.answers = JSON.parse(checkIn.answers)
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.error('Failed to parse check-in answers:', e)
-    }
     res.render('pages/practitioners/checkins/view', { checkIn })
   } catch (error) {
     next(error)

--- a/server/controllers/submissionController.ts
+++ b/server/controllers/submissionController.ts
@@ -4,6 +4,9 @@ import logger from '../../logger'
 import { services } from '../services'
 import LocationInfo from '../data/models/locationInfo'
 import getUserFriendlyString from '../utils/userFriendlyStrings'
+import MentalHealth from '../data/models/survey/mentalHealth'
+import SupportAspect from '../data/models/survey/supportAspect'
+import CallbackRequested from '../data/models/survey/callbackRequested'
 
 const { esupervisionService, faceCompareService } = services()
 
@@ -211,24 +214,24 @@ export const handleSubmission: RequestHandler = async (req, res, next) => {
   } = res.locals.formData
 
   const submissionId = getSubmissionId(req)
-  const data = {
+  const submission = {
     offender: res.locals.submission.offender.uuid,
-    answers: JSON.stringify({
-      mentalHealth,
-      assistance,
-      mentalHealthSupport,
-      alcoholSupport,
-      drugsSupport,
-      moneySupport,
-      housingSupport,
-      supportSystemSupport,
-      otherSupport,
-      callback,
-      callbackDetails,
-    }),
+    survey: {
+      mentalHealth: mentalHealth as MentalHealth,
+      assistance: assistance as SupportAspect[],
+      mentalHealthSupport: mentalHealthSupport as string,
+      alcoholSupport: alcoholSupport as string,
+      drugsSupport: drugsSupport as string,
+      moneySupport: moneySupport as string,
+      housingSupport: housingSupport as string,
+      supportSystemSupport: supportSystemSupport as string,
+      otherSupport: otherSupport as string,
+      callback: callback as CallbackRequested,
+      callbackDetails: callbackDetails as string,
+    },
   }
   try {
-    await esupervisionService.submitCheckin(submissionId, data)
+    await esupervisionService.submitCheckin(submissionId, submission)
   } catch (error) {
     next(error)
   }

--- a/server/data/models/checkin.ts
+++ b/server/data/models/checkin.ts
@@ -2,6 +2,7 @@ import CheckinStatus from './checkinStatus'
 import PersonOnProbation from './personOnProbation'
 import AutomatedIdVerificationResult from './automatedIdVerificationResult'
 import ManualIdVerificationResult from './manualIdVerificationResult'
+import SurveyResponse from './survey/surveyResponse'
 
 export default class Checkin {
   uuid: string
@@ -16,7 +17,7 @@ export default class Checkin {
 
   questions: string // TODO: find out structure
 
-  answers: string // TODO: find out structure
+  surveyResponse: SurveyResponse
 
   createdBy: string // TODO: parse uuid
 

--- a/server/data/models/checkinSubmission.ts
+++ b/server/data/models/checkinSubmission.ts
@@ -1,5 +1,7 @@
+import SurveyResponse from './survey/surveyResponse'
+
 export default class CheckinSubmission {
   offender: string // TODO: require uuid
 
-  answers: string // TODO: fix structure
+  survey: SurveyResponse
 }

--- a/server/data/models/createCheckinRequest.ts
+++ b/server/data/models/createCheckinRequest.ts
@@ -3,7 +3,5 @@ export default class CreateCheckinRequest {
 
   offender: string // TODO: require uuid?
 
-  questions: string // TODO: fix structure
-
   dueDate: string // TODO: require date?
 }

--- a/server/data/models/survey/callbackRequested.ts
+++ b/server/data/models/survey/callbackRequested.ts
@@ -1,0 +1,6 @@
+enum CallbackRequested {
+  Yes = 'YES',
+  NO = 'NO',
+}
+
+export default CallbackRequested

--- a/server/data/models/survey/callbackRequested.ts
+++ b/server/data/models/survey/callbackRequested.ts
@@ -1,6 +1,6 @@
 enum CallbackRequested {
   Yes = 'YES',
-  NO = 'NO',
+  No = 'NO',
 }
 
 export default CallbackRequested

--- a/server/data/models/survey/mentalHealth.ts
+++ b/server/data/models/survey/mentalHealth.ts
@@ -1,0 +1,9 @@
+enum MentalHealth {
+  VeryWell = 'VERY_WELL',
+  Well = 'WELL',
+  Ok = 'OK',
+  NotGreat = 'NOT_GREAT',
+  Struggling = 'STRUGGLING',
+}
+
+export default MentalHealth

--- a/server/data/models/survey/supportAspect.ts
+++ b/server/data/models/survey/supportAspect.ts
@@ -1,0 +1,19 @@
+enum SupportAspect {
+  MentalHealth = 'MENTAL_HEALTH',
+
+  Alcohol = 'ALCOHOL',
+
+  Drugs = 'DRUGS',
+
+  Money = 'MONEY',
+
+  Housing = 'HOUSING',
+
+  SupportSystem = 'SUPPORT_SYSTEM',
+
+  Other = 'OTHER',
+
+  NoHelp = 'NO_HELP',
+}
+
+export default SupportAspect

--- a/server/data/models/survey/surveyResponse.ts
+++ b/server/data/models/survey/surveyResponse.ts
@@ -1,0 +1,27 @@
+import MentalHealth from './mentalHealth'
+import SupportAspect from './supportAspect'
+import CallbackRequested from './callbackRequested'
+
+export default class SurveyResponse {
+  mentalHealth: MentalHealth
+
+  assistance: SupportAspect[]
+
+  mentalHealthSupport: string
+
+  alcoholSupport: string
+
+  drugsSupport: string
+
+  moneySupport: string
+
+  housingSupport: string
+
+  supportSystemSupport: string
+
+  otherSupport: string
+
+  callback: CallbackRequested
+
+  callbackDetails: string
+}

--- a/server/views/pages/practitioners/cases/invite.njk
+++ b/server/views/pages/practitioners/cases/invite.njk
@@ -11,10 +11,6 @@ index.njk{% extends "../layout.njk" %}
           <label class="govuk-label" for="dueDate">Due date</label>
           <input class="govuk-input" id="dueDate" name="dueDate" type="date" required />
         </div>
-        <div class="govuk-form-group">
-          <label class="govuk-label" for="message">Questions</label>
-          <textarea class="govuk-textarea" id="questions" name="questions" rows="5">questions</textarea>
-        </div>
         <button type="submit" class="govuk-button">Create invite</button>
       </form>
     </div>

--- a/server/views/pages/practitioners/checkins/view.njk
+++ b/server/views/pages/practitioners/checkins/view.njk
@@ -82,74 +82,74 @@
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Mental health</dt>
-          <dd class="govuk-summary-list__value">{{ checkIn.answers.mentalHealth }}</dd>
+          <dd class="govuk-summary-list__value">{{ checkIn.surveyResponse.mentalHealth }}</dd>
           <dd class="govuk-summary-list__actions"></dd>
         </div>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Anything they need help with</dt>
-          <dd class="govuk-summary-list__value">{{ checkIn.answers.assistance }}</dd>
+          <dd class="govuk-summary-list__value">{{ checkIn.surveyResponse.assistance }}</dd>
           <dd class="govuk-summary-list__actions"></dd>
         </div>
 
-        {% if checkIn.answers.mentalHealthSupport %}
+        {% if checkIn.surveyResponse.mentalHealthSupport %}
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Mental health</dt>
-            <dd class="govuk-summary-list__value">{{ checkIn.answers.mentalHealthSupport }}</dd>
+            <dd class="govuk-summary-list__value">{{ checkIn.surveyResponse.mentalHealthSupport }}</dd>
             <dd class="govuk-summary-list__actions"></dd>
           </div>
         {% endif %}
-        {% if checkIn.answers.alcoholSupport %}
+        {% if checkIn.surveyResponse.alcoholSupport %}
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Alcohol</dt>
-            <dd class="govuk-summary-list__value">{{ checkIn.answers.alcoholSupport }}</dd>
+            <dd class="govuk-summary-list__value">{{ checkIn.surveyResponse.alcoholSupport }}</dd>
             <dd class="govuk-summary-list__actions"></dd>
           </div>
         {% endif %}
-        {% if checkIn.answers.drugsSupport %}
+        {% if checkIn.surveyResponse.drugsSupport %}
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Drugs</dt>
-            <dd class="govuk-summary-list__value">{{ checkIn.answers.drugsSupport }}</dd>
+            <dd class="govuk-summary-list__value">{{ checkIn.surveyResponse.drugsSupport }}</dd>
             <dd class="govuk-summary-list__actions"></dd>
           </div>
         {% endif %}
-        {% if checkIn.answers.moneySupport %}
+        {% if checkIn.surveyResponse.moneySupport %}
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Money</dt>
-            <dd class="govuk-summary-list__value">{{ checkIn.answers.moneySupport }}</dd>
+            <dd class="govuk-summary-list__value">{{ checkIn.surveyResponse.moneySupport }}</dd>
             <dd class="govuk-summary-list__actions"></dd>
           </div>
         {% endif %}
-        {% if checkIn.answers.housingSupport %}
+        {% if checkIn.surveyResponse.housingSupport %}
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Housing</dt>
-            <dd class="govuk-summary-list__value">{{ checkIn.answers.housingSupport }}</dd>
+            <dd class="govuk-summary-list__value">{{ checkIn.surveyResponse.housingSupport }}</dd>
             <dd class="govuk-summary-list__actions"></dd>
           </div>
         {% endif %}
-        {% if checkIn.answers.supportSystemSupport %}
+        {% if checkIn.surveyResponse.supportSystemSupport %}
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Support system</dt>
-            <dd class="govuk-summary-list__value">{{ checkIn.answers.supportSystemSupport }}</dd>
+            <dd class="govuk-summary-list__value">{{ checkIn.surveyResponse.supportSystemSupport }}</dd>
             <dd class="govuk-summary-list__actions"></dd>
           </div>
         {% endif %}
-        {% if checkIn.answers.otherSupport %}
+        {% if checkIn.surveyResponse.otherSupport %}
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Other</dt>
-            <dd class="govuk-summary-list__value">{{ checkIn.answers.otherSupport }}</dd>
+            <dd class="govuk-summary-list__value">{{ checkIn.surveyResponse.otherSupport }}</dd>
             <dd class="govuk-summary-list__actions"></dd>
           </div>
         {% endif %}
 
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Contact with practitioner requested</dt>
-          <dd class="govuk-summary-list__value">{{ checkIn.answers.callback }}</dd>
+          <dd class="govuk-summary-list__value">{{ checkIn.surveyResponse.callback }}</dd>
           <dd class="govuk-summary-list__actions"></dd>
         </div>
-        {% if checkIn.answers.callbackDetails %}
+        {% if checkIn.surveyResponse.callbackDetails %}
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">What needs to be discussed</dt>
-            <dd class="govuk-summary-list__value">{{ checkIn.answers.callbackDetails }}</dd>
+            <dd class="govuk-summary-list__value">{{ checkIn.surveyResponse.callbackDetails }}</dd>
             <dd class="govuk-summary-list__actions"></dd>
           </div>
         {% endif %}


### PR DESCRIPTION
The API now represents survey responses explicitly in checkin submission and info DTOs so add these to the model. Survey questions are fixed in advance so remove the unused 'questions' textbox on submission invite.