### PR TITLE
Add version info to surveys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "passport": "^0.7.0",
         "passport-oauth2": "^1.8.0",
         "redis": "^4.7.0",
+        "source-map-support": "^0.5.21",
         "superagent": "^10.2.1",
         "uuid": "^11.1.0",
         "zod": "^3.25.51"
@@ -6471,7 +6472,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bunyan": {
@@ -11176,6 +11176,17 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/jest-runtime": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
@@ -15149,7 +15160,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -15166,10 +15176,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "passport": "^0.7.0",
     "passport-oauth2": "^1.8.0",
     "redis": "^4.7.0",
+    "source-map-support": "^0.5.21",
     "superagent": "^10.2.1",
     "uuid": "^11.1.0",
     "zod": "^3.25.51"

--- a/server.ts
+++ b/server.ts
@@ -3,6 +3,7 @@ import 'applicationinsights'
 
 import app from './server/index'
 import logger from './logger'
+import 'source-map-support/register'
 
 app.listen(app.get('port'), () => {
   logger.info(`Server listening on port ${app.get('port')}`)

--- a/server/controllers/submissionController.ts
+++ b/server/controllers/submissionController.ts
@@ -217,6 +217,7 @@ export const handleSubmission: RequestHandler = async (req, res, next) => {
   const submission = {
     offender: res.locals.submission.offender.uuid,
     survey: {
+      version: '2025-07-10@pilot',
       mentalHealth: mentalHealth as MentalHealth,
       assistance: assistance as SupportAspect[],
       mentalHealthSupport: mentalHealthSupport as string,

--- a/server/controllers/submissionController.ts
+++ b/server/controllers/submissionController.ts
@@ -231,13 +231,13 @@ export const handleSubmission: RequestHandler = async (req, res, next) => {
       callbackDetails: callbackDetails as string,
     },
   }
+
   try {
     await esupervisionService.submitCheckin(submissionId, submission)
+    res.redirect(`/submission/${submissionId}/confirmation`)
   } catch (error) {
     next(error)
   }
-
-  res.redirect(`/submission/${submissionId}/confirmation`)
 }
 
 export const renderConfirmation: RequestHandler = async (req, res, next) => {

--- a/server/data/models/survey/surveyResponse.ts
+++ b/server/data/models/survey/surveyResponse.ts
@@ -2,7 +2,15 @@ import MentalHealth from './mentalHealth'
 import SupportAspect from './supportAspect'
 import CallbackRequested from './callbackRequested'
 
-export default class SurveyResponse {
+export type SurveyVersion = string
+
+export interface Versioned {
+  version: SurveyVersion
+}
+
+export default class SurveyResponse implements Versioned {
+  version: SurveyVersion
+
   mentalHealth: MentalHealth
 
   assistance: SupportAspect[]


### PR DESCRIPTION
This is needed to make sure we know what logic to use on the backend to compute the list of flagged files.

Associated backend PR: https://github.com/ministryofjustice/hmpps-esupervision-api/pull/36
