### PR TITLE
Submit checkin start date and frequency when registering new PoP

### DIFF
--- a/server/controllers/practitionersController.ts
+++ b/server/controllers/practitionersController.ts
@@ -347,7 +347,7 @@ export const renderCheckAnswers: RequestHandler = async (req, res, next) => {
 export const handleRegister: RequestHandler = async (req, res, next) => {
   const { firstName, lastName, day, month, year, contactPreference, email, mobile, frequency } = res.locals.formData
   const { startDateYear, startDateMonth, startDateDay } = res.locals.formData
-  const nextCheckinDate = new Date(startDateYear as number, (startDateMonth as number) - 1, startDateDay as number)
+  const firstCheckinDate = new Date(startDateYear as number, (startDateMonth as number) - 1, startDateDay as number)
 
   const data = {
     setupUuid: uuidv4(),
@@ -357,7 +357,7 @@ export const handleRegister: RequestHandler = async (req, res, next) => {
     dateOfBirth: year ? format(`${year}-${month}-${day}`, 'yyyy-MM-dd') : null,
     email: contactPreference === 'EMAIL' && email ? email.toString() : null, // Only include email if contact preference is EMAIL
     phoneNumber: contactPreference === 'TEXT' && mobile ? mobile.toString() : null, // Only include mobile if contact preference is TEXT
-    nextCheckinDate: format(nextCheckinDate, 'yyyy-MM-dd'),
+    firstCheckinDate: format(firstCheckinDate, 'yyyy-MM-dd'),
     checkinInterval: frequency as CheckinInterval,    
   }
   try {

--- a/server/controllers/practitionersController.ts
+++ b/server/controllers/practitionersController.ts
@@ -358,7 +358,7 @@ export const handleRegister: RequestHandler = async (req, res, next) => {
     email: contactPreference === 'EMAIL' && email ? email.toString() : null, // Only include email if contact preference is EMAIL
     phoneNumber: contactPreference === 'TEXT' && mobile ? mobile.toString() : null, // Only include mobile if contact preference is TEXT
     firstCheckinDate: format(firstCheckinDate, 'yyyy-MM-dd'),
-    checkinInterval: frequency as CheckinInterval,    
+    checkinInterval: frequency as CheckinInterval,
   }
   try {
     const setup = await esupervisionService.createOffender(data)

--- a/server/controllers/practitionersController.ts
+++ b/server/controllers/practitionersController.ts
@@ -5,6 +5,7 @@ import { services } from '../services'
 import Checkin from '../data/models/checkin'
 import Page from '../data/models/page'
 import getUserFriendlyString from '../utils/userFriendlyStrings'
+import CheckinInterval from '../data/models/checkinInterval'
 
 const { esupervisionService } = services()
 
@@ -344,7 +345,9 @@ export const renderCheckAnswers: RequestHandler = async (req, res, next) => {
 }
 
 export const handleRegister: RequestHandler = async (req, res, next) => {
-  const { firstName, lastName, day, month, year, contactPreference, email, mobile } = res.locals.formData
+  const { firstName, lastName, day, month, year, contactPreference, email, mobile, frequency } = res.locals.formData
+  const { startDateYear, startDateMonth, startDateDay } = res.locals.formData
+  const nextCheckinDate = new Date(startDateYear as number, (startDateMonth as number) - 1, startDateDay as number)
 
   const data = {
     setupUuid: uuidv4(),
@@ -354,6 +357,8 @@ export const handleRegister: RequestHandler = async (req, res, next) => {
     dateOfBirth: year ? format(`${year}-${month}-${day}`, 'yyyy-MM-dd') : null,
     email: contactPreference === 'EMAIL' && email ? email.toString() : null, // Only include email if contact preference is EMAIL
     phoneNumber: contactPreference === 'TEXT' && mobile ? mobile.toString() : null, // Only include mobile if contact preference is TEXT
+    nextCheckinDate: format(nextCheckinDate, 'yyyy-MM-dd'),
+    checkinInterval: frequency as CheckinInterval,    
   }
   try {
     const setup = await esupervisionService.createOffender(data)

--- a/server/data/models/checkinInterval.ts
+++ b/server/data/models/checkinInterval.ts
@@ -1,0 +1,7 @@
+enum CheckinInterval {
+  Weekly = 'WEEKLY',
+  TwoWeeks = 'TWO_WEEKS',
+  FourWeeks = 'FOUR_WEEKS',
+}
+
+export default CheckinInterval

--- a/server/data/models/offenderInfo.ts
+++ b/server/data/models/offenderInfo.ts
@@ -1,3 +1,5 @@
+import CheckinInterval from './checkinInterval'
+
 export default class OffenderInfo {
   setupUuid: string
 
@@ -12,4 +14,8 @@ export default class OffenderInfo {
   email: string
 
   phoneNumber: string
+
+  nextCheckinDate: string
+
+  checkinInterval: CheckinInterval
 }

--- a/server/data/models/offenderInfo.ts
+++ b/server/data/models/offenderInfo.ts
@@ -15,7 +15,7 @@ export default class OffenderInfo {
 
   phoneNumber: string
 
-  nextCheckinDate: string
+  firstCheckinDate: string
 
   checkinInterval: CheckinInterval
 }

--- a/server/schemas/practitionersSchemas.ts
+++ b/server/schemas/practitionersSchemas.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { isFuture } from 'date-fns'
+import { isFuture, isToday } from 'date-fns'
 
 export const personsDetailsSchema = z
   .object({
@@ -71,10 +71,10 @@ export const setUpSchema = z
   .refine(
     ({ startDateDay, startDateMonth, startDateYear }) => {
       const d = new Date(startDateYear, startDateMonth - 1, startDateDay)
-      return isFuture(d)
+      return isFuture(d) || isToday(d)
     },
     {
-      message: 'Date must be in the future',
+      message: 'Date must be in the future or today',
       path: ['startDate'],
     },
   )


### PR DESCRIPTION
The API now requires the date of the next checkin and the checkin frequency when registering a new PoP. Add model type for the valid checkin intervals and add it to the PoP information within the handlerRegister handler.

Associated API PR: https://github.com/ministryofjustice/hmpps-esupervision-api/pull/37