### PR TITLE
Query offenders by practitioner

### DIFF
--- a/server/controllers/practitionersController.ts
+++ b/server/controllers/practitionersController.ts
@@ -85,7 +85,7 @@ export const renderCases: RequestHandler = async (req, res, next) => {
     const page = req.query.page ? parseInt(req.query.page as string, 10) : 0
     const size = req.query.size ? parseInt(req.query.size as string, 10) : 20
 
-    const cases = await esupervisionService.getOffenders(page, size)
+    const cases = await esupervisionService.getOffenders(practitionerUuid, page, size)
     // eslint-disable-next-line prefer-destructuring
     res.locals.successMessage = req.flash('success')[0]
     res.render('pages/practitioners/cases/index', { cases, practitionerUuid, page, size })

--- a/server/data/esupervisionApiClient.ts
+++ b/server/data/esupervisionApiClient.ts
@@ -39,11 +39,11 @@ export default class EsupervisionApiClient extends RestClient {
     )
   }
 
-  getOffenders(page: number, size: number): Promise<Page<OffenderInfo>> {
+  getOffenders(practitionerUuid: string, page: number, size: number): Promise<Page<OffenderInfo>> {
     return this.get<Page<OffenderInfo>>(
       {
         path: '/offenders',
-        query: { page, size },
+        query: { practitionerUuid, page, size },
       },
       asSystem(),
     )

--- a/server/services/esupervisionService.ts
+++ b/server/services/esupervisionService.ts
@@ -32,8 +32,8 @@ export default class EsupervisionService {
     return this.esupervisionApiClient.getCheckinFrameUploadLocation(submissionId, contentType)
   }
 
-  getOffenders(page: number, size: number): Promise<Page<OffenderInfo>> {
-    return this.esupervisionApiClient.getOffenders(page, size)
+  getOffenders(practitionerUuid: string, page: number, size: number): Promise<Page<OffenderInfo>> {
+    return this.esupervisionApiClient.getOffenders(practitionerUuid, page, size)
   }
 
   submitCheckin(checkinId: string, submission: CheckinSubmission): Promise<Checkin> {


### PR DESCRIPTION
With this change (and associated API change) the dashboard will only show offenders who have been assigned to the current practitioner.

Related API PR: https://github.com/ministryofjustice/hmpps-esupervision-api/pull/39