### PR TITLE
Simplify checkin upload location API

### DIFF
--- a/server/controllers/submissionController.ts
+++ b/server/controllers/submissionController.ts
@@ -2,7 +2,6 @@ import { RequestHandler, Request } from 'express'
 import { isEqual } from 'date-fns'
 import logger from '../../logger'
 import { services } from '../services'
-import LocationInfo from '../data/models/locationInfo'
 import MentalHealth from '../data/models/survey/mentalHealth'
 import SupportAspect from '../data/models/survey/supportAspect'
 import CallbackRequested from '../data/models/survey/callbackRequested'
@@ -27,6 +26,7 @@ export const handleRedirect = (submissionPath: string): RequestHandler => {
     const { submissionId } = req.params
     const basePath = `/submission/${submissionId}`
     let redirectUrl = `${basePath}${submissionPath}`
+    logger.info('handleRedirect: ', { checkAnswers: req.query.checkAnswers, redirectUrl })
 
     if (req.query.checkAnswers === 'true') {
       redirectUrl = `${basePath}/check-your-answers`
@@ -85,13 +85,6 @@ export const renderVideoRecord: RequestHandler = async (req, res, next) => {
     const { submissionId } = req.params
     const videoContentType = 'video/mp4'
     const frameContentType = 'image/jpeg'
-    const promises = [
-      esupervisionService.getCheckinVideoUploadLocation(submissionId, videoContentType),
-      esupervisionService.getCheckinFrameUploadLocation(submissionId, frameContentType),
-    ]
-    const [videoResult, framesResult] = await Promise.all(promises)
-    const videoUploadLocation = videoResult as LocationInfo
-    const frameUploadLocations = framesResult as LocationInfo[]
 
     const checkIn = res.locals.submission
     const offenderPhoto = checkIn.offender.photoUrl
@@ -103,11 +96,24 @@ export const renderVideoRecord: RequestHandler = async (req, res, next) => {
       return response.blob()
     })
 
-    const [referencePhotoUploadUrl, ...snapshotPhotoUploadUrls] = frameUploadLocations.map(location => location.url)
-    const referencePhotoUploadResult = await fetch(referencePhotoUploadUrl, {
+    const uploadLocations = await esupervisionService.getCheckinUploadLocation(submissionId, {
+      video: videoContentType,
+      reference: offenderReferencePhoto.type,
+      snapshots: [frameContentType, frameContentType],
+    })
+
+    if (
+      uploadLocations.references.length === 0 ||
+      uploadLocations.snapshots.length === 0 ||
+      uploadLocations.video === undefined
+    ) {
+      throw new Error(`Failed to get upload locations: ${JSON.stringify(uploadLocations)}`)
+    }
+
+    const referencePhotoUploadResult = await fetch(uploadLocations.references[0].url, {
       method: 'PUT',
       headers: {
-        'Content-Type': offenderReferencePhoto.type,
+        'Content-Type': uploadLocations.references[0].contentType,
       },
       body: offenderReferencePhoto,
     })
@@ -115,13 +121,13 @@ export const renderVideoRecord: RequestHandler = async (req, res, next) => {
     if (!referencePhotoUploadResult.ok) {
       throw new Error(`Failed to upload reference photo: ${referencePhotoUploadResult.statusText}`)
     } else {
-      logger.debug('Reference photo uploaded successfully', referencePhotoUploadUrl)
+      logger.debug('Reference photo uploaded successfully', uploadLocations.references[0].url)
     }
 
     res.render('pages/submission/video/record', {
       ...pageParams(req),
-      videoUploadUrl: videoUploadLocation.url,
-      frameUploadUrl: snapshotPhotoUploadUrls,
+      videoUploadUrl: uploadLocations.video.url,
+      frameUploadUrl: uploadLocations.snapshots.map(snapshot => snapshot.url),
     })
   } catch (error) {
     next(error)

--- a/server/data/esupervisionApiClient.ts
+++ b/server/data/esupervisionApiClient.ts
@@ -6,6 +6,7 @@ import Page from './models/page'
 import Checkin from './models/checkin'
 import CreateCheckinRequest from './models/createCheckinRequest'
 import UploadLocationResponse from './models/uploadLocationResponse'
+import CheckinUploadLocationResponse from './models/checkinUploadLocationResponse'
 import LocationInfo from './models/locationInfo'
 import CheckinSubmission from './models/checkinSubmission'
 import OffenderInfo from './models/offenderInfo'
@@ -14,6 +15,15 @@ import AutomatedIdVerificationResult from './models/automatedIdVerificationResul
 import Practitioner from './models/pracitioner'
 import PractitionerSetup from './models/pracitionerSetup'
 import Offender from './models/offender'
+
+/**
+ * Specifies content types for possible upload locations for a checkin.
+ */
+export type CheckinUploadContentTypes = {
+  video: string
+  reference: string
+  snapshots: string[]
+}
 
 export default class EsupervisionApiClient extends RestClient {
   constructor(authenticationClient: AuthenticationClient) {
@@ -49,38 +59,21 @@ export default class EsupervisionApiClient extends RestClient {
     )
   }
 
-  async getCheckinVideoUploadLocation(checkinId: string, videoContentType: string): Promise<LocationInfo> {
-    const location = await this.post<UploadLocationResponse>(
+  async getCheckinUploadLocation(
+    checkinId: string,
+    contentTypes: CheckinUploadContentTypes,
+  ): Promise<CheckinUploadLocationResponse> {
+    const { video, reference, snapshots } = contentTypes
+    const locations = await this.post<CheckinUploadLocationResponse>(
       {
         path: `/offender_checkins/${checkinId}/upload_location`,
-        query: { 'content-type': videoContentType },
+        query: { video, reference, snapshots: snapshots.join(',') },
         headers: { 'Content-Type': 'application/json' },
       },
       asSystem(),
     )
 
-    if (location.errorMessage && location.locationInfo) {
-      throw new Error(`Failed to get video upload location: ${location.errorMessage}`)
-    } else {
-      return location.locationInfo
-    }
-  }
-
-  async getCheckinFrameUploadLocation(checkinId: string, frameContentType: string): Promise<LocationInfo[]> {
-    const location = await this.post<UploadLocationResponse>(
-      {
-        path: `/offender_checkins/${checkinId}/upload_location`,
-        query: { 'content-type': frameContentType, 'num-snapshots': 2 },
-        headers: { 'Content-Type': 'application/json' },
-      },
-      asSystem(),
-    )
-
-    if (location.errorMessage && location.locations) {
-      throw new Error(`Failed to get snapshot upload location: ${location.errorMessage}`)
-    } else {
-      return location.locations
-    }
+    return locations
   }
 
   async getProfilePhotoUploadLocation(offenderSetup: OffenderSetup, photoContentType: string): Promise<LocationInfo> {

--- a/server/data/models/checkinUploadLocationResponse.ts
+++ b/server/data/models/checkinUploadLocationResponse.ts
@@ -1,0 +1,9 @@
+import LocationInfo from './locationInfo'
+
+export default class CheckinUploadLocationResponse {
+  references?: LocationInfo[]
+
+  snapshots?: LocationInfo[]
+
+  video?: LocationInfo
+}

--- a/server/services/esupervisionService.ts
+++ b/server/services/esupervisionService.ts
@@ -1,4 +1,4 @@
-import EsupervisionApiClient from '../data/esupervisionApiClient'
+import EsupervisionApiClient, { CheckinUploadContentTypes } from '../data/esupervisionApiClient'
 import Page from '../data/models/page'
 import Checkin from '../data/models/checkin'
 
@@ -12,6 +12,7 @@ import AutomatedIdVerificationResult from '../data/models/automatedIdVerificatio
 import Practitioner from '../data/models/pracitioner'
 import PractitionerSetup from '../data/models/pracitionerSetup'
 import Offender from '../data/models/offender'
+import CheckinUploadLocationResponse from '../data/models/checkinUploadLocationResponse'
 
 export default class EsupervisionService {
   constructor(private readonly esupervisionApiClient: EsupervisionApiClient) {}
@@ -24,12 +25,11 @@ export default class EsupervisionService {
     return this.esupervisionApiClient.getCheckin(submissionId)
   }
 
-  getCheckinVideoUploadLocation(submissionId: string, videoContentType: string): Promise<LocationInfo> {
-    return this.esupervisionApiClient.getCheckinVideoUploadLocation(submissionId, videoContentType)
-  }
-
-  getCheckinFrameUploadLocation(submissionId: string, contentType: string): Promise<LocationInfo[]> {
-    return this.esupervisionApiClient.getCheckinFrameUploadLocation(submissionId, contentType)
+  getCheckinUploadLocation(
+    submissionId: string,
+    contentTypes: CheckinUploadContentTypes,
+  ): Promise<CheckinUploadLocationResponse> {
+    return this.esupervisionApiClient.getCheckinUploadLocation(submissionId, contentTypes)
   }
 
   getOffenders(practitionerUuid: string, page: number, size: number): Promise<Page<OffenderInfo>> {

--- a/server/services/faceCompareService.ts
+++ b/server/services/faceCompareService.ts
@@ -30,7 +30,8 @@ export default class FaceCompareService {
 
     try {
       const result = await this.rekognitionClient.send(Commmand)
-      logger.info('Compared the video still with the stored image', result)
+      // logger.debug('Compared the video still with the stored image', result)
+      logger.info('Face compare: face matches', result.FaceMatches)
 
       let bestMatch: { Similarity: number } = { Similarity: 0.0 }
       if (result.FaceMatches.length > 0) {

--- a/server/views/pages/submission/video/record.njk
+++ b/server/views/pages/submission/video/record.njk
@@ -31,9 +31,9 @@
             id="videoContainer"
             data-video-upload-url="{{ videoUploadUrl }}"
             data-submission-id="{{ submissionId }}"
-            {% for frame in frameUploadUrl %}
-              data-image-upload-url="{{ frame }}"
-            {% endfor %}
+            {% if frameUploadUrl.length > 0 %}
+              data-image-upload-url="{{ frameUploadUrl[0] }}"
+            {% endif %}
           >
             <div class="videoRecorder__videoWrap">
               <video id="video" class="videoRecorder__video" autoplay muted playsinline></video>


### PR DESCRIPTION
The API was simplified and no longer requires multiple calls to get the upload locations. Additionally, the response is more straightforward to use.

Relevant API PR: https://github.com/ministryofjustice/hmpps-esupervision-api/pull/40