### PR TITLE
Load entire AWS rekognition configuration from secret

### DIFF
--- a/helm_deploy/hmpps-esupervision-ui/values.yaml
+++ b/helm_deploy/hmpps-esupervision-ui/values.yaml
@@ -33,8 +33,6 @@ generic-service:
     TOKEN_VERIFICATION_ENABLED: 'true'
     AUDIT_SQS_REGION: 'eu-west-2'
     AUDIT_SERVICE_NAME: 'UNASSIGNED' # Your audit service name
-    REKOG_AWS_REGION: 'eu-west-2'
-    REKOG_S3_DATA_BUCKET: 'user-ids-rekognition-d-2'
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
@@ -57,6 +55,8 @@ generic-service:
     hmpps-esupervision-ui-application-insights:
       APPLICATIONINSIGHTS_CONNECTION_STRING: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
     hmpps-esupervision-rekog-aws:
+      REKOG_AWS_REGION: 'region'
+      REKOG_S3_DATA_BUCKET: 'bucket_name'
       REKOG_AWS_ACCESS_KEY_ID: 'aws_access_key_id'
       REKOG_AWS_SECRET_ACCESS_KEY: 'aws_secret_access_key'
     # This secret will need to be created in your namespace (note it isn't in hmpps-templates-dev)

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,8 +14,6 @@ generic-service:
     ESUPERVISION_API_URL: 'https://esupervision-api-dev.hmpps.service.justice.gov.uk'
     ENVIRONMENT_NAME: DEV
     AUDIT_ENABLED: 'false'
-    REKOG_AWS_REGION: 'eu-west-2'
-    REKOG_S3_DATA_BUCKET: 'user-ids-rekognition-d-2'
 
 generic-prometheus-alerts:
   alertSeverity: hmpps_esupervision_alerts_nonprod

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -14,8 +14,6 @@ generic-service:
     ESUPERVISION_API_URL: 'https://esupervision-api-test.hmpps.service.justice.gov.uk'
     ENVIRONMENT_NAME: TEST
     AUDIT_ENABLED: 'false'
-    REKOG_AWS_REGION: 'eu-west-2'
-    REKOG_S3_DATA_BUCKET: 'user-ids-rekognition-d-2'
 
 generic-prometheus-alerts:
   alertSeverity: hmpps_esupervision_alerts_nonprod


### PR DESCRIPTION
The bucket name and region have been added to the
hmpps-esupervision-rekog-aws secret within each environment. Load this config from the secret instead of specifying within helm config for each environment.