### PR TITLE
Update zod schemas to give friendly error messages

### DIFF
--- a/server/schemas/practitionersSchemas.ts
+++ b/server/schemas/practitionersSchemas.ts
@@ -22,18 +22,33 @@ export const personsDetailsSchema = z
 
 export const videoReviewSchema = z
   .object({
-    reviewed: z.enum(['YES', 'NO']).describe('Select yes if the person is in the video'),
+    reviewed: z
+      .enum(['YES', 'NO'], {
+        error: issue => (issue.input === undefined ? 'Select yes if the person is in the video' : issue.message),
+      })
+      .describe('Select yes if the person is in the video'),
   })
   .required()
 
 export const contactPreferenceSchema = z
   .object({
-    contactPreference: z.string().describe('Choose how you would like us to send a link'),
+    contactPreference: z
+      .string({
+        error: issue => (issue.input === undefined ? 'Select how you would like us to send a link' : issue.message),
+      })
+      .describe('Choose how you would like us to send a link'),
   })
   .required()
 
 export const emailSchema = z.object({
-  email: z.email().describe('Enter an email address in the correct format, like name@example.com'),
+  email: z
+    .email({
+      error: issue =>
+        issue.input === undefined
+          ? 'Enter an email address in the correct format, like name@example.com'
+          : issue.message,
+    })
+    .describe('Enter an email address in the correct format, like name@example.com'),
 })
 
 export const mobileSchema = z.object({
@@ -50,7 +65,14 @@ export const setUpSchema = z
     startDateDay: z.coerce.number({ message: 'Enter a valid day' }).positive({ message: 'Enter day' }),
     startDateMonth: z.coerce.number({ message: 'Enter a valid month' }).positive({ message: 'Enter month' }),
     startDateYear: z.coerce.number({ message: 'Enter a valid year' }).positive({ message: 'Enter year' }),
-    frequency: z.string().describe('Select how often you would like the person to submit online checks'),
+    frequency: z
+      .string({
+        error: issue =>
+          issue.input === undefined
+            ? 'Select how often you would like the person to submit online checks'
+            : issue.message,
+      })
+      .describe('Select how often you would like the person to submit online checks'),
   })
   .refine(
     ({ startDateDay, startDateMonth, startDateYear }) => {

--- a/server/schemas/submissionSchemas.ts
+++ b/server/schemas/submissionSchemas.ts
@@ -42,11 +42,15 @@ const validCircumstances = [
   'NO_HELP',
 ] as const
 
-export const mentalHealthSchema = z
-  .object({
-    mentalHealth: z.enum(['VERY_WELL', 'WELL', 'OK', 'NOT_GREAT', 'STRUGGLING']).describe('Select how you are feeling'),
+const MentalHealthEnum = z
+  .enum(['VERY_WELL', 'WELL', 'OK', 'NOT_GREAT', 'STRUGGLING'], {
+    error: issue => (issue.input === undefined ? 'Select how you are feeling' : issue.message),
   })
-  .required()
+  .describe('Select how you are feeling')
+
+export const mentalHealthSchema = z.object({
+  mentalHealth: MentalHealthEnum,
+})
 
 export const assistanceSchema = z.object({
   assistance: z.preprocess(
@@ -61,12 +65,24 @@ export const assistanceSchema = z.object({
 
 export const callbackSchema = z
   .object({
-    callback: z.enum(['YES', 'NO']).describe('Select yes if you need to speak to your probation practitioner'),
+    callback: z
+      .enum(['YES', 'NO'], {
+        error: issue => {
+          return issue.input === undefined
+            ? 'Select yes if you need to speak to your probation practitioner'
+            : issue.message
+        },
+      })
+      .describe('Select yes if you need to speak to your probation practitioner'),
   })
   .required()
 
 export const checkAnswersSchema = z
   .object({
-    checkAnswers: z.enum(['CONFIRM']).describe('Confirm your details are correct'),
+    checkAnswers: z
+      .enum(['CONFIRM'], {
+        error: issue => (issue.input === undefined ? 'Confirm your details are correct' : issue.message),
+      })
+      .describe('Confirm your details are correct'),
   })
   .required()


### PR DESCRIPTION
More updates to zod schemas required to make them return "user friendy" messages. Without these changes we got messages like this:

<img width="1566" height="476" alt="image" src="https://github.com/user-attachments/assets/7135b785-36cf-49d9-8468-73d1a3f49cc3" />

But we wanted "Confirm your details are correct"