### PR TITLE
Maake `/register/begin` into a POST endpoint

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -187,13 +187,16 @@ if (registerButton) {
     // Disable the button to prevent multiple submissions
     registerButton.setAttribute('disabled', 'disabled')
 
-    const registerResult = await fetch(`/practitioners/register/details`, {
-      method: 'GET',
+    const registerResult = await fetch(`/practitioners/register/begin`, {
+      method: 'POST',
+      headers: {
+        'x-csrf-token': document.querySelector('input[name=_csrf]').value,
+      },
     })
       .then(res => res.json())
       .catch(error => {
         // eslint-disable-next-line no-console
-        console.error(error)
+        console.warn(error)
         return { status: 'ERROR', message: `Registration failed` }
       })
 

--- a/server/middleware/setUpCsrf.ts
+++ b/server/middleware/setUpCsrf.ts
@@ -14,7 +14,7 @@ export default function setUpCsrf(): Router {
       // By default, csrf-sync uses x-csrf-token header, but we use the token in forms and send it in the request body, so change getTokenFromRequest so it grabs from there
       getTokenFromRequest: req => {
         // eslint-disable-next-line no-underscore-dangle
-        return req.body._csrf
+        return req.body?._csrf || req.headers['x-csrf-token']
       },
     })
 

--- a/server/routes/practitionersRoutes.ts
+++ b/server/routes/practitionersRoutes.ts
@@ -131,7 +131,7 @@ export default function routes(): Router {
 
   // The following two routes start and end the setup process on the backend
   // At the moment, `/begin` is called from client (browser), `/complete` is called from server
-  get('/register/begin', handleRegisterBegin)
+  router.post('/register/begin', handleRegisterBegin)
   router.post('/register/complete', handleRegisterComplete)
 
   return router


### PR DESCRIPTION
Seems more appropriate as it initiates the setup process on the backend.

This required passing the csrf token.