### PR TITLE
Only apply service allowlist in dev environment

### DIFF
--- a/helm_deploy/hmpps-esupervision-ui/values.yaml
+++ b/helm_deploy/hmpps-esupervision-ui/values.yaml
@@ -64,9 +64,5 @@ generic-service:
     # sqs-hmpps-audit-secret:
     #   AUDIT_SQS_QUEUE_URL: 'sqs_queue_url'
 
-  allowlist:
-    groups:
-      - internal
-
 generic-prometheus-alerts:
   targetApplication: hmpps-esupervision-ui

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -7,6 +7,10 @@ generic-service:
   ingress:
     host: esupervision-dev.hmpps.service.justice.gov.uk
 
+  allowlist:
+    groups:
+      - internal
+
   env:
     INGRESS_URL: 'https://esupervision-dev.hmpps.service.justice.gov.uk'
     HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'


### PR DESCRIPTION
Move the ingress allowlist to values-dev.yaml so it only applies there. Other environments should (currently) be accessible from the internet.