### PR TITLE
Add types to allow allow passing extra data related to checkin

### DIFF
--- a/server/controllers/practitionersController.ts
+++ b/server/controllers/practitionersController.ts
@@ -86,8 +86,8 @@ const filterCheckIns = (checkIns: Page<Checkin>, filter: string = 'as') => {
     let reviewDueDate = null
     if (checkIn.status === 'EXPIRED') {
       reviewDueDate = add(new Date(checkIn.dueDate), { days: 6 }).toString()
-    } else if (checkIn.submittedOn) {
-      reviewDueDate = add(new Date(checkIn.submittedOn), { days: 3 })
+    } else if (checkIn.submittedAt) {
+      reviewDueDate = add(new Date(checkIn.submittedAt), { days: 3 })
     }
     return {
       checkInId: checkIn.uuid,
@@ -95,7 +95,7 @@ const filterCheckIns = (checkIns: Page<Checkin>, filter: string = 'as') => {
       offenderId: offender.uuid,
       sentTo: offender.email || offender.phoneNumber,
       flagged: autoIdCheck === 'NO_MATCH' || checkIn.flaggedResponses.length > 0 || checkIn.status === 'EXPIRED',
-      receivedDate: checkIn.submittedOn,
+      receivedDate: checkIn.submittedAt,
       dueDate: add(new Date(dueDate), { days: 3 }),
       reviewDueDate,
       status: friendlyCheckInStatus(status),
@@ -124,7 +124,7 @@ export const renderCheckInDetail: RequestHandler = async (req, res, next) => {
     const { checkin: checkIn } = await esupervisionService.getCheckin(checkInId)
     checkIn.dueDate = add(new Date(checkIn.dueDate), { days: 3 }).toString()
     if (checkIn.status === 'SUBMITTED') {
-      checkIn.reviewDueDate = add(new Date(checkIn.submittedOn), { days: 3 }).toString()
+      checkIn.reviewDueDate = add(new Date(checkIn.submittedAt), { days: 3 }).toString()
     } else if (checkIn.status === 'EXPIRED') {
       checkIn.reviewDueDate = add(new Date(checkIn.dueDate), { days: 6 }).toString()
     }

--- a/server/controllers/practitionersController.ts
+++ b/server/controllers/practitionersController.ts
@@ -121,7 +121,7 @@ const friendlyCheckInStatus = (status: string) => {
 export const renderCheckInDetail: RequestHandler = async (req, res, next) => {
   try {
     const { checkInId } = req.params
-    const checkIn = await esupervisionService.getCheckin(checkInId)
+    const { checkin: checkIn } = await esupervisionService.getCheckin(checkInId)
     checkIn.dueDate = add(new Date(checkIn.dueDate), { days: 3 }).toString()
     if (checkIn.status === 'SUBMITTED') {
       checkIn.reviewDueDate = add(new Date(checkIn.submittedOn), { days: 3 }).toString()
@@ -138,8 +138,8 @@ export const renderCheckInDetail: RequestHandler = async (req, res, next) => {
 export const renderCheckInVideoDetail: RequestHandler = async (req, res, next) => {
   try {
     const { checkInId } = req.params
-    const checkIn = await esupervisionService.getCheckin(checkInId)
-    res.render('pages/practitioners/checkins/video', { checkIn })
+    const { checkin: checkIn, checkinLogs } = await esupervisionService.getCheckin(checkInId)
+    res.render('pages/practitioners/checkins/video', { checkIn, checkinLogs })
   } catch (error) {
     next(error)
   }

--- a/server/data/esupervisionApiClient.ts
+++ b/server/data/esupervisionApiClient.ts
@@ -15,6 +15,7 @@ import Practitioner from './models/pracitioner'
 import PractitionerSetup from './models/pracitionerSetup'
 import Offender from './models/offender'
 import OffenderUpdate from './models/offenderUpdate'
+import OffenderCheckinResponse from './models/offenderCheckinResponse'
 import AutomaticCheckinVerificationResult from './models/automaticCheckinVerificationResult'
 
 /**
@@ -41,8 +42,8 @@ export default class EsupervisionApiClient extends RestClient {
     )
   }
 
-  getCheckin(checkinId: string, includeUploads?: boolean): Promise<Checkin> {
-    return this.get<Checkin>(
+  getCheckin(checkinId: string, includeUploads?: boolean): Promise<OffenderCheckinResponse> {
+    return this.get<OffenderCheckinResponse>(
       {
         path: `/offender_checkins/${checkinId}`,
         query: { 'include-uploads': includeUploads },

--- a/server/data/models/checkin.ts
+++ b/server/data/models/checkin.ts
@@ -13,23 +13,25 @@ export default class Checkin {
 
   offender: PersonOnProbation
 
-  submittedOn: string // TODO: parse datetime
+  submittedAt?: string // TODO: parse datetime
 
   questions: string // TODO: find out structure
 
-  surveyResponse: SurveyResponse
+  surveyResponse?: SurveyResponse
 
   createdBy: string // TODO: parse uuid
 
   createdAt: string // TODO: parse datetime
 
-  reviewedBy: string // TODO: parse uuid
+  reviewedBy?: string // TODO: parse uuid
+
+  reviewedAt?: string
 
   videoUrl: string // TODO: parse url?
 
-  autoIdCheck: AutomatedIdVerificationResult
+  autoIdCheck?: AutomatedIdVerificationResult
 
-  manualIdCheck: ManualIdVerificationResult
+  manualIdCheck?: ManualIdVerificationResult
 
   flaggedResponses: string[]
 

--- a/server/data/models/offenderCheckinLogs.ts
+++ b/server/data/models/offenderCheckinLogs.ts
@@ -1,0 +1,12 @@
+export default class OffenderCheckinLogs {
+  hint: 'ALL' | 'SUBSET' | 'OMITTED'
+
+  logs: {
+    logEntryType: string
+    comment: string
+    practitioner: string
+    offender: string
+    createdAt: string
+    checkin: string
+  }[]
+}

--- a/server/data/models/offenderCheckinResponse.ts
+++ b/server/data/models/offenderCheckinResponse.ts
@@ -1,0 +1,8 @@
+import Checkin from './checkin'
+import OffenderCheckinLogs from './offenderCheckinLogs'
+
+export default class OffenderCheckinResponse {
+  checkin: Checkin
+
+  checkinLogs: OffenderCheckinLogs
+}

--- a/server/services/esupervisionService.ts
+++ b/server/services/esupervisionService.ts
@@ -13,6 +13,7 @@ import PractitionerSetup from '../data/models/pracitionerSetup'
 import Offender from '../data/models/offender'
 import CheckinUploadLocationResponse from '../data/models/checkinUploadLocationResponse'
 import OffenderUpdate from '../data/models/offenderUpdate'
+import OffenderCheckinResponse from '../data/models/offenderCheckinResponse'
 import AutomaticCheckinVerificationResult from '../data/models/automaticCheckinVerificationResult'
 
 export default class EsupervisionService {
@@ -22,7 +23,7 @@ export default class EsupervisionService {
     return this.esupervisionApiClient.getCheckins(practitionerUuid, page, size)
   }
 
-  getCheckin(submissionId: string, includeUploads?: boolean): Promise<Checkin> {
+  getCheckin(submissionId: string, includeUploads?: boolean): Promise<OffenderCheckinResponse> {
     return this.esupervisionApiClient.getCheckin(submissionId, includeUploads)
   }
 

--- a/server/views/pages/practitioners/checkins/view.njk
+++ b/server/views/pages/practitioners/checkins/view.njk
@@ -80,7 +80,7 @@
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Checked in on</dt>
-        <dd class="govuk-summary-list__value">{{ checkIn.submittedOn | gdsDateTime }}</dd>
+        <dd class="govuk-summary-list__value">{{ checkIn.submittedAt | gdsDateTime }}</dd>
       </div>
       {% if checkIn.status == "REVIEWED" %}
         <div class="govuk-summary-list__row">

--- a/server/views/pages/submission/check-answers.njk
+++ b/server/views/pages/submission/check-answers.njk
@@ -167,7 +167,7 @@
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Video check</dt>
           <dd class="govuk-summary-list__value">
-            {{ 'We have confirmed this is you' if submission.autoIdCheck == 'MATCH' else 'We cannot confirm this is you' }}
+            {{ 'We have confirmed this is you' if submission.checkin.autoIdCheck == 'MATCH' else 'We cannot confirm this is you' }}
           </dd>
           <dd class="govuk-summary-list__actions">
             <a class="govuk-link" href="/submission/{{ submissionId }}/video/view?checkAnswers=true"

--- a/server/views/pages/submission/video/view.njk
+++ b/server/views/pages/submission/video/view.njk
@@ -21,7 +21,7 @@
         <h1 class="govuk-heading-l">We have confirmed this is you</h1>
         <p>We have confirmed this is you. You can now continue to check your answers.</p>
         <div class="videoRecorder__videoWrap">
-          <video class="videoRecorder__video-preview" id="matchPreview" src="{{ submission.videoUrl }}" controls>
+          <video class="videoRecorder__video-preview" id="matchPreview" src="{{ submission.checkin.videoUrl }}" controls>
             Your browser does not support video
           </video>
         </div>
@@ -40,7 +40,7 @@
           We have checked and we cannot confirm this is you. You can try recording again or submit your video anyway.
         </p>
         <div class="videoRecorder__videoWrap">
-          <video class="videoRecorder__video-preview" id="noMatchPreview" src="{{ submission.videoUrl }}" controls>
+          <video class="videoRecorder__video-preview" id="noMatchPreview" src="{{ submission.checkin.videoUrl }}" controls>
             Your browser does not support video
           </video>
         </div>


### PR DESCRIPTION
Adds `OffenderCheckinResponse` container type to allow returning checkin logs (and other extra bits in the future) without adding more fields to the checkin object

Also updates the `Checkin` model to match what API returns.

This is required to match changes in the API: https://github.com/ministryofjustice/hmpps-esupervision-api/pull/57