### PR TITLE
Allow practitioner to review missed checkin

### DIFF
--- a/server/data/esupervisionApiClient.ts
+++ b/server/data/esupervisionApiClient.ts
@@ -116,12 +116,23 @@ export default class EsupervisionApiClient extends RestClient {
     )
   }
 
-  async reviewCheckin(practitionerUuid: string, checkinId: string, match: boolean): Promise<Checkin> {
+  async reviewCheckin(
+    practitionerUuid: string,
+    checkinId: string,
+    match?: boolean,
+    missedCheckinComment?: string,
+  ): Promise<Checkin> {
+    const requestBody = {
+      practitioner: practitionerUuid,
+      manualIdCheck: match ? 'MATCH' : 'NO_MATCH',
+      missedCheckinComment,
+    }
+
     return this.post<Checkin>(
       {
         path: `/offender_checkins/${checkinId}/review`,
         headers: { 'Content-Type': 'application/json' },
-        data: JSON.stringify({ practitioner: practitionerUuid, manualIdCheck: match ? 'MATCH' : 'NO_MATCH' }),
+        data: JSON.stringify(requestBody),
       },
       asSystem(),
     )

--- a/server/schemas/practitionersSchemas.ts
+++ b/server/schemas/practitionersSchemas.ts
@@ -17,9 +17,20 @@ export const personsDetailsSchema = z
   })
   .and(dobSchema)
 
-export const videoReviewSchema = z
+export const expiredCheckinReviewSchema = z
   .object({
-    reviewed: z
+    checkinStatus: z.literal(['EXPIRED']),
+    missedCheckinComment: z
+      .string()
+      .nonempty({ message: 'Enter the reason they did not complete their checkin' })
+      .describe('Enter the reason they did not complete their checkin'),
+  })
+  .required()
+
+export const submittedCheckinReviewSchema = z
+  .object({
+    checkinStatus: z.literal(['SUBMITTED']),
+    idVerification: z
       .enum(['YES', 'NO'], {
         error: issue =>
           issue.input === undefined ? 'Select yes if the person in the video is the correct person' : issue.message,
@@ -27,6 +38,11 @@ export const videoReviewSchema = z
       .describe('Select yes if the person in the video is the correct person'),
   })
   .required()
+
+export const videoReviewSchema = z.discriminatedUnion('checkinStatus', [
+  expiredCheckinReviewSchema,
+  submittedCheckinReviewSchema,
+])
 
 export const contactPreferenceSchema = z
   .object({

--- a/server/services/esupervisionService.ts
+++ b/server/services/esupervisionService.ts
@@ -42,8 +42,13 @@ export default class EsupervisionService {
     return this.esupervisionApiClient.submitCheckin(checkinId, submission)
   }
 
-  reviewCheckin(practitionerUuid: string, checkinId: string, match: boolean): Promise<Checkin> {
-    return this.esupervisionApiClient.reviewCheckin(practitionerUuid, checkinId, match)
+  reviewCheckin(
+    practitionerUuid: string,
+    checkinId: string,
+    match?: boolean,
+    missedCheckinComment?: string,
+  ): Promise<Checkin> {
+    return this.esupervisionApiClient.reviewCheckin(practitionerUuid, checkinId, match, missedCheckinComment)
   }
 
   createOffender(offenderInfo: OffenderInfo): Promise<OffenderSetup> {

--- a/server/views/pages/practitioners/checkins/view.njk
+++ b/server/views/pages/practitioners/checkins/view.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% extends "../layout.njk" %}
 {% from "../../../partials/errorSummary.njk" import errorSummary %}
 
@@ -70,6 +71,36 @@
             <dd class="govuk-summary-list__value">{{ checkIn.reviewDueDate | gdsDate }}</dd>
           </div>
         </dl>
+        {% set noCheckinLabel = "Why did " + checkIn.offender.firstName + " " + checkIn.offender.lastName + " not complete their check-in?" %}
+        {% if notSubmittedLog %}
+          <h2 class="govuk-heading-m">{{ noCheckinLabel }}</h2>
+          <p>{{ notSubmittedLog.comment }}</p>
+        {% else %}
+          <form method="POST">
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+            <input type="hidden" name="checkinStatus" value="{{ checkIn.status }}" />
+            {{
+              govukTextarea({
+                name: "missedCheckinComment",
+                id: "missed-checkin-comment",
+                label: {
+                  text: noCheckinLabel,
+                  classes: "govuk-label--m",
+                  isPageHeading: false
+                },
+                hint: {
+                  text: "For example, the person did not have access to device"
+                },
+                errorMessage: validationErrors | findError("missedCheckinComment")
+              })
+            }}
+            {{
+              govukButton({
+                text: "Mark as reviewed"
+              })
+            }}
+          {% endif %}
+      </form>
       </div>
     </div>
   {% else %}
@@ -92,7 +123,7 @@
           <dt class="govuk-summary-list__key">Review due</dt>
           <dd class="govuk-summary-list__value">
             {% if checkIn.reviewDueDate %}
-              {{ checkIn.reviewDueDate | gdsDate }}
+              {{ checkIn.reviewDueDate | gdsDateTime }}
             {% else %}
               Not set
             {% endif %}
@@ -252,10 +283,11 @@
     {% if checkIn.status == "SUBMITTED" %}
       <form method="POST">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+        <input type="hidden" name="checkinStatus" value="{{ checkIn.status }}" />
         {{
           govukRadios({
-          name: "reviewed",
-          errorMessage: validationErrors | findError("reviewed"),
+          name: "idVerification",
+          errorMessage: validationErrors | findError("idVerification"),
           fieldset: {
             legend: {
               text: "Is the person in the video " + checkIn.offender.firstName + " " + checkIn.offender.lastName + "?",

--- a/server/views/pages/practitioners/dashboard.njk
+++ b/server/views/pages/practitioners/dashboard.njk
@@ -106,7 +106,7 @@
             <tr>
               <td class="govuk-table__cell" data-label="Name">{{ checkin.offenderName }}</td>
               <td class="govuk-table__cell" data-label="Status">{{ checkin.status }}</td>
-              <td class="govuk-table__cell" data-label="Reviewed on">-</td>
+              <td class="govuk-table__cell" data-label="Reviewed on">{% if checkin.reviewedAt %}{{ checkin.reviewedAt | gdsDateTime }}{% else %}-{% endif %}</td>
               <td class="govuk-table__cell govuk-table__cell--numeric" data-label="Action">
                 <a href="/practitioners/checkin/{{ checkin.checkInId }}" class="govuk-link govuk-link--no-visited-state"
                   >View<span class="govuk-visually-hidden">


### PR DESCRIPTION
- allow to review expired checkins (requires the practitioner to provide a comment, e.g. reason why checkin was not submitted)
- updated schema for the 'checkin review' page
- update the dashboard filtering code to put the reviewed EXPIRED checkin in the right tab