### PR TITLE
Offender checkin session timeout

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -5,6 +5,7 @@ export declare module 'express-session' {
   interface SessionData {
     returnTo: string
     nowInMinutes: number
+    submissionAuthorized?: number
     formData?: {
       circumstances?: string | string[]
       policeContact?: string

--- a/server/config.ts
+++ b/server/config.ts
@@ -47,6 +47,7 @@ export default {
   session: {
     secret: get('SESSION_SECRET', 'app-insecure-default-session', requiredInProduction),
     expiryMinutes: Number(get('WEB_SESSION_TIMEOUT_IN_MINUTES', 120)),
+    ofenderSessionTimeoutMinutes: Number(get('OFFENDER_SESSION_TIMEOUT_IN_MINUTES', 5)),
   },
   apis: {
     hmppsAuth: {

--- a/server/controllers/submissionController.ts
+++ b/server/controllers/submissionController.ts
@@ -50,7 +50,9 @@ export const renderIndex: RequestHandler = async (req, res, next) => {
 
 export const renderVerify: RequestHandler = async (req, res, next) => {
   try {
-    res.render('pages/submission/verify', pageParams(req))
+    const errors = req.flash('error')
+
+    res.render('pages/submission/verify', { ...pageParams(req), errorMessage: errors[0] })
   } catch (error) {
     next(error)
   }
@@ -73,6 +75,8 @@ export const handleVerify: RequestHandler = async (req, res: Response<object, Su
   if (!isMatch) {
     return res.render('pages/submission/no-match-found', { firstName, lastName, dateOfBirth, submissionId })
   }
+
+  req.session.submissionAuthorized = Date.now()
   return res.redirect(`/submission/${submissionId}/questions/mental-health`)
 }
 
@@ -275,6 +279,7 @@ export const handleSubmission: RequestHandler = async (req, res: Response<object
 
 export const renderConfirmation: RequestHandler = async (req, res, next) => {
   try {
+    req.session = null
     res.render('pages/submission/confirmation', pageParams(req))
   } catch (error) {
     next(error)

--- a/server/middleware/submissionMiddleware.ts
+++ b/server/middleware/submissionMiddleware.ts
@@ -1,0 +1,23 @@
+import { RequestHandler } from 'express'
+import config from '../config'
+
+const protectSubmission: RequestHandler = (req, res, next) => {
+  const sessionStart = req.session.submissionAuthorized
+  const sessionTimeout = config.session.ofenderSessionTimeoutMinutes * 60 * 1000
+  if (!sessionStart || Date.now() - sessionStart > sessionTimeout) {
+    const { submissionId } = req.params
+
+    req.session.submissionAuthorized = undefined
+    req.session.formData.firstName = undefined
+    req.session.formData.lastName = undefined
+    req.session.formData.day = undefined
+    req.session.formData.month = undefined
+    req.session.formData.year = undefined
+
+    req.flash('error', { title: 'Your session has expired. Please start again.' })
+    return res.redirect(`/submission/${submissionId}/verify`)
+  }
+  return next()
+}
+
+export default protectSubmission

--- a/server/views/pages/submission/verify.njk
+++ b/server/views/pages/submission/verify.njk
@@ -1,3 +1,4 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
@@ -17,6 +18,15 @@
 {% endblock %}
 
 {% block content %}
+  {% if errorMessage %}
+    {{
+      govukNotificationBanner({
+        html: '<p class="govuk-body">' + errorMessage.title + '</p>',
+        type: 'error',
+        titleId: 'error-title'
+      })
+    }}
+  {% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {{ errorSummary(validationErrors) }}


### PR DESCRIPTION
- add config option to control the timeout in minutes
- adds middleware on the submission routes that monitors session duration and redirects to /verify step if over the time limit

- updates the template to show message about expired session
- added checkin status check, so once a checkin is SUBMITTED it won't let you try to go through the process again (the API won't allow submission anyway)