### PR TITLE
ESUP-568: Add custom error page for checkin session timeout

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -56,7 +56,7 @@ export default {
   session: {
     secret: get('SESSION_SECRET', 'app-insecure-default-session', requiredInProduction),
     expiryMinutes: Number(get('WEB_SESSION_TIMEOUT_IN_MINUTES', 120)),
-    ofenderSessionTimeoutMinutes: Number(get('OFFENDER_SESSION_TIMEOUT_IN_MINUTES', 5)),
+    ofenderSessionTimeoutMinutes: Number(get('OFFENDER_SESSION_TIMEOUT_IN_MINUTES', 30)),
   },
   apis: {
     hmppsAuth: {

--- a/server/middleware/submissionMiddleware.ts
+++ b/server/middleware/submissionMiddleware.ts
@@ -8,14 +8,9 @@ const protectSubmission: RequestHandler = (req, res, next) => {
     const { submissionId } = req.params
 
     req.session.submissionAuthorized = undefined
-    req.session.formData.firstName = undefined
-    req.session.formData.lastName = undefined
-    req.session.formData.day = undefined
-    req.session.formData.month = undefined
-    req.session.formData.year = undefined
+    req.session.formData = undefined
 
-    req.flash('error', { title: 'Your session has expired. Please start again.' })
-    return res.redirect(`/submission/${submissionId}/verify`)
+    return res.render('pages/submission/timeout', { checkinUrl: `/submission/${submissionId}/verify` })
   }
   return next()
 }

--- a/server/views/pages/submission/timeout.njk
+++ b/server/views/pages/submission/timeout.njk
@@ -1,0 +1,19 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = "You chceck in has been reset" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+      <p>For your security, your answers have been deleted.</p>
+      {{
+          govukButton({
+            text: "Restart check in",
+            href: checkinUrl
+          })
+      }}
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
And replaces the temporary `flash()` info message