### PR TITLE
ESUP-564: remember ID verification result

### DIFF
--- a/server/controllers/submissionController.ts
+++ b/server/controllers/submissionController.ts
@@ -13,8 +13,10 @@ const { esupervisionService } = services()
 
 const getSubmissionId = (req: Request): string => req.params.submissionId
 const pageParams = (req: Request): Record<string, string | boolean> => {
+  const cya = req.query.checkAnswers === 'true'
   return {
-    cya: req.query.checkAnswers === 'true',
+    cya,
+    autoVerifyResult: cya ? (req.session.formData.autoVerifyResult as string) : '',
     submissionId: getSubmissionId(req),
   }
 }
@@ -151,6 +153,7 @@ export const handleVideoVerify: RequestHandler = async (req, res, next) => {
     res.setHeader('Connection', 'keep-alive')
 
     const result = await esupervisionService.autoVerifyCheckinIdentity(submissionId, 1)
+    req.session.formData.autoVerifyResult = result.result
 
     res.json({ status: 'SUCCESS', result: result.result })
   } catch (error) {

--- a/server/views/pages/submission/video/view.njk
+++ b/server/views/pages/submission/video/view.njk
@@ -17,7 +17,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% if submission.autoIdCheck == 'MATCH' %}
+      {% if submission.autoIdCheck == 'MATCH' or autoVerifyResult == 'MATCH' %}
         <h1 class="govuk-heading-l">We have confirmed this is you</h1>
         <p>We have confirmed this is you. You can now continue to check your answers.</p>
         <div class="videoRecorder__videoWrap">


### PR DESCRIPTION
This fixes the issue where going from 'check your answers' page to the 'view video' page would display "We can't confirm you ID" even if the check was previously successful.