### PR TITLE
Update application name from template application

### DIFF
--- a/helm_deploy/hmpps-esupervision-ui/Chart.yaml
+++ b/helm_deploy/hmpps-esupervision-ui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 appVersion: '1.0'
 description: A Helm chart for Kubernetes
-name: hmpps-template-typescript
+name: hmpps-esupervision-ui
 version: 0.2.0
 dependencies:
   - name: generic-service

--- a/helm_deploy/hmpps-esupervision-ui/values.yaml
+++ b/helm_deploy/hmpps-esupervision-ui/values.yaml
@@ -3,7 +3,7 @@ generic-service:
   productId: 'HMPPS9999' # productId for the product that this belongs too, i.e. DPS001, see README.md for details
 
   # the IRSA service account name for accessing AWS resources
-  # serviceAccountName: "hmpps-template-typescript"
+  # serviceAccountName: "hmpps-esupervision-api"
 
   replicaCount: 4
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,5 +1,5 @@
 ---
-# Per environment values which override defaults in hmpps-template-typescript/values.yaml
+# Per environment values which override defaults in hmpps-esupervision-ui/values.yaml
 
 generic-service:
   replicaCount: 2

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,5 +1,5 @@
 ---
-# Per environment values which override defaults in hmpps-template-typescript/values.yaml
+# Per environment values which override defaults in hmpps-esupervision-ui/values.yaml
 
 generic-service:
   replicaCount: 2

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,5 +1,5 @@
 ---
-# Per environment values which override defaults in hmpps-template-typescript/values.yaml
+# Per environment values which override defaults in hmpps-esupervision-ui/values.yaml
 
 generic-service:
   ingress:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -1,5 +1,5 @@
 ---
-# Per environment values which override defaults in hmpps-template-typescript/values.yaml
+# Per environment values which override defaults in hmpps-esupervision-ui/values.yaml
 
 generic-service:
   replicaCount: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "hmpps-template-typescript",
+  "name": "hmpps-esupervision-ui",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "hmpps-template-typescript",
+      "name": "hmpps-esupervision-ui",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "hmpps-template-typescript",
+  "name": "hmpps-esupervision-ui",
   "version": "0.0.1",
   "description": "HMPPS eSupervision",
-  "repository": "git@github.com:ministryofjustice/hmpps-template-typescript.git",
+  "repository": "git@github.com:ministryofjustice/hmpps-esupervision-ui.git",
   "license": "MIT",
   "scripts": {
     "prepare": "husky",


### PR DESCRIPTION
Issue ESUP-373 - Update the application name in the package definition, helm chart and within the comments in each environmental config file.

The application name within package.json is returned within the /health and /info endpoints which is used to identify the UI application within application insights.