### PR TITLE
add data-checkin-uuid attribute to checkin rows in dashboard

### DIFF
--- a/server/views/pages/practitioners/dashboard.njk
+++ b/server/views/pages/practitioners/dashboard.njk
@@ -64,7 +64,7 @@
         </thead>
         <tbody class="govuk-table__body">
           {% for checkin in checkIns %}
-            <tr>
+            <tr data-checkin-uuid="{{ checkin.checkInId }}">
               <td class="govuk-table__cell" data-label="Name">{{ checkin.offenderName }}</td>
               <td class="govuk-table__cell" data-label="Status">{{ checkin.status }}</td>
               <td class="govuk-table__cell" data-label="Review due">{{ checkin.reviewDueDate  | gdsDate }} &nbsp;</td>
@@ -103,7 +103,7 @@
         </thead>
         <tbody class="govuk-table__body">
           {% for checkin in checkIns %}
-            <tr>
+            <tr data-checkin-uuid="{{ checkin.checkInId }}">
               <td class="govuk-table__cell" data-label="Name">{{ checkin.offenderName }}</td>
               <td class="govuk-table__cell" data-label="Status">{{ checkin.status }}</td>
               <td class="govuk-table__cell" data-label="Reviewed on">
@@ -138,7 +138,7 @@
         </thead>
         <tbody class="govuk-table__body">
           {% for checkin in checkIns %}
-            <tr>
+            <tr data-checkin-uuid="{{ checkin.checkInId }}">
               <td class="govuk-table__cell" data-label="Name">{{ checkin.offenderName }}</td>
               <td class="govuk-table__cell" data-label="Link sent to">{{ checkin.sentTo }}</td>
               <td class="govuk-table__cell" data-label="Status">{{ checkin.status }}</td>


### PR DESCRIPTION
The Delius team has automated tests to trigger messages from external systems to delius. They would like add tests for our service. Currently they’d be able to do it by using the “Debug” feature in the front end. We would’t like other teams to rely on this feature, but it makes sense to expose the relevant pieces of data in the markup (e.g. they won’t be visible on screen, but testing tools will be able to find it).

The proposed solution is to add a data-checkin-uuid attribute to the rows in “Awaiting checkin” table where possible. 