### PR TITLE
Deny users not in the required role access to the dashboard

### DIFF
--- a/server/middleware/authorisationMiddleware.test.ts
+++ b/server/middleware/authorisationMiddleware.test.ts
@@ -44,14 +44,14 @@ describe('authorisationMiddleware', () => {
     expect(res.redirect).not.toHaveBeenCalled()
   })
 
-  // it('should redirect when user has no authorised roles', () => {
-  //   const res = createResWithToken({ authorities: [] })
-  //
-  //   authorisationMiddleware(['SOME_REQUIRED_ROLE'])(req, res, next)
-  //
-  //   expect(next).not.toHaveBeenCalled()
-  //   expect(res.redirect).toHaveBeenCalledWith('/authError')
-  // })
+  it('should redirect when user has no authorised roles', () => {
+    const res = createResWithToken({ authorities: [] })
+
+    authorisationMiddleware(['SOME_REQUIRED_ROLE'])(req, res, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(res.redirect).toHaveBeenCalledWith('/authError')
+  })
 
   it('should return next when user has authorised role', () => {
     const res = createResWithToken({ authorities: ['ROLE_SOME_REQUIRED_ROLE'] })

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -27,7 +27,7 @@ export default function authorisationMiddleware(authorisedRoles: string[] = []):
         } else {
           logger.error(`User ${name} (${userName}) is not authorised to access dashboard`)
           logger.error(`User has roles '${roles}', required one of ${authorisedAuthorities}`)
-          // return res.redirect('/authError')
+          return res.redirect('/authError')
         }
       }
 


### PR DESCRIPTION
Issue ESUP-601 - All users should now have been assigned to the required role so deny any users without it access to the dashboard.