### PR TITLE
Middleware to restrict access to UK traffic only

### DIFF
--- a/helm_deploy/hmpps-esupervision-ui/values.yaml
+++ b/helm_deploy/hmpps-esupervision-ui/values.yaml
@@ -54,10 +54,13 @@ generic-service:
       REDIS_AUTH_TOKEN: 'auth_token'
     hmpps-esupervision-ui-application-insights:
       APPLICATIONINSIGHTS_CONNECTION_STRING: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+    ipinfo-token:
+      IPINFO_TOKEN: 'token'
     # This secret will need to be created in your namespace (note it isn't in hmpps-templates-dev)
     # IRSA configuration in your namespace will also be required, and then uncomment serviceAccountName above.
     # sqs-hmpps-audit-secret:
     #   AUDIT_SQS_QUEUE_URL: 'sqs_queue_url'
+
 
 generic-prometheus-alerts:
   targetApplication: hmpps-esupervision-ui

--- a/helm_deploy/hmpps-esupervision-ui/values.yaml
+++ b/helm_deploy/hmpps-esupervision-ui/values.yaml
@@ -54,8 +54,8 @@ generic-service:
       REDIS_AUTH_TOKEN: 'auth_token'
     hmpps-esupervision-ui-application-insights:
       APPLICATIONINSIGHTS_CONNECTION_STRING: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
-    ipinfo-token:
-      IPINFO_TOKEN: 'token'
+    ip-info-token:
+      IP_INFO_TOKEN: 'token'
     # This secret will need to be created in your namespace (note it isn't in hmpps-templates-dev)
     # IRSA configuration in your namespace will also be required, and then uncomment serviceAccountName above.
     # sqs-hmpps-audit-secret:

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "http-errors": "^2.0.0",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
+        "lru-cache": "^11.2.2",
         "nocache": "^4.0.0",
         "nunjucks": "^3.2.4",
         "passport": "^0.7.0",
@@ -948,6 +949,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -11901,13 +11912,12 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
       "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/make-dir": {
@@ -13008,16 +13018,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
-      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/path-type": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "http-errors": "^2.0.0",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
+    "lru-cache": "^11.2.2",
     "nocache": "^4.0.0",
     "nunjucks": "^3.2.4",
     "passport": "^0.7.0",

--- a/server/app.ts
+++ b/server/app.ts
@@ -22,6 +22,7 @@ import practitionersRoutes from './routes/practitionersRoutes'
 import featureFlags from './middleware/featureFlags'
 
 import type { Services } from './services'
+import restrictToUK from './middleware/restrictToUK'
 
 export default function createApp(services: Services): express.Application {
   const app = express()
@@ -52,6 +53,8 @@ export default function createApp(services: Services): express.Application {
   app.use(bodyParser.json())
   app.use(storeFormDataInSession())
   app.use(populateValidationErrors())
+
+  app.use(restrictToUK)
 
   app.use(routes())
 

--- a/server/middleware/restrictToUK.ts
+++ b/server/middleware/restrictToUK.ts
@@ -1,0 +1,130 @@
+import type { Request, Response, NextFunction } from 'express'
+import { LRUCache } from 'lru-cache'
+import { z } from 'zod'
+import logger from '../../logger'
+
+const IP_INFO_TOKEN = process.env.IP_INFO_TOKEN ?? ''
+const ALLOWED_COUNTRY = 'GB'
+const BYPASS_PATHS = ['/health', '/ping', '/assets', '/info'] // health check and static asset paths
+const CACHE_TTL_MS = 1000 * 60 * 60 * 24 // 1 day
+
+const cache = new LRUCache<string, { countryCode: string | null }>({
+  max: 10_000,
+  ttl: CACHE_TTL_MS,
+})
+
+const IPInfoAPISchema = z.object({
+  ip: z.string().optional(),
+  asn: z.string().optional(),
+  as_name: z.string().optional(),
+  as_domain: z.string().optional(),
+  country_code: z.string().length(2).optional(),
+  country: z.string().optional(),
+  continent_code: z.string().optional(),
+  continent: z.string().optional(),
+})
+
+function normaliseIp(ip: string | undefined | null): string {
+  if (!ip) return ''
+  return ip.startsWith('::ffff:') ? ip.slice(7) : ip
+}
+
+function getClientIp(req: Request): string {
+  const xff = req.headers['x-forwarded-for']
+  if (typeof xff === 'string' && xff.length > 0) {
+    const first = xff.split(',')[0].trim()
+    if (first) return normaliseIp(first)
+  }
+  return normaliseIp(req.ip || req.socket?.remoteAddress || '')
+}
+
+function localDevBypass(ip: string): boolean {
+  if (!ip) return true
+  if (ip === '::1' || ip.startsWith('127.')) return true // localhost
+  if (ip.startsWith('10.') || ip.startsWith('192.168.')) return true // common private ranges
+  if (ip.startsWith('172.')) {
+    const oct = Number(ip.split('.')[1])
+    if (oct >= 16 && oct <= 31) return true
+  }
+  return false
+}
+
+function isAllowed(countryCode: string | null): boolean {
+  return (countryCode ?? '').toUpperCase() === ALLOWED_COUNTRY
+}
+
+export default async function restrictToUK(req: Request, res: Response, next: NextFunction) {
+  try {
+    // 1) Bypass specific paths
+    if (BYPASS_PATHS.some(prefix => req.path.startsWith(prefix))) {
+      return next()
+    }
+
+    // 2) If missing token, log a warning and allow user to access the site
+    if (!IP_INFO_TOKEN) {
+      logger.warn({ path: req.path }, 'IP_INFO_TOKEN not set - allowing traffic')
+      return next()
+    }
+
+    // 3) Get IP
+    const ip = getClientIp(req)
+
+    // 4) Allow local development to bypass
+    if (localDevBypass(ip)) return next()
+
+    // 5) Cache
+    const cached = cache.get(ip)
+    if (cached) {
+      if (!isAllowed(cached.countryCode)) {
+        logger.warn({ ip, country: cached.countryCode }, 'Blocked non-UK request (cache)')
+        return res.status(403).render('pages/outside-uk')
+      }
+      return next()
+    }
+
+    // 6) Lookup IP information
+    const url = `https://api.ipinfo.io/lite/${ip}?token=${IP_INFO_TOKEN}`
+
+    try {
+      const resp = await fetch(url)
+
+      if (!resp.ok) {
+        logger.error({ ip, status: resp.status }, 'IP lookup failed')
+        // Allow user to continue on failure
+        return next()
+      }
+
+      const json = await resp.json()
+
+      const parsed = IPInfoAPISchema.safeParse(json)
+      if (!parsed.success) {
+        const issues = parsed.error.issues.map(err => err.message)
+        logger.error({ ip, issues }, 'IP lookup response validation failed')
+        // Allow user to continue on failure
+        return next()
+      }
+
+      const { data } = parsed
+      const countryCode = data.country_code ?? null
+
+      // 7) Cache result
+      cache.set(ip, { countryCode })
+
+      // 8) Enforce UK/GB only
+      if (!isAllowed(countryCode)) {
+        logger.warn({ ip, country: countryCode }, 'Blocked non-UK request')
+        return res.status(403).render('pages/outside-uk')
+      }
+
+      return next()
+    } catch (e) {
+      logger.error({ ip, err: e }, 'IP lookup error')
+      // Allow user to continue on failure
+      return next()
+    }
+  } catch (err) {
+    logger.error({ err }, 'restrictToUK middleware error')
+    // Allow user to continue on failure
+    return next()
+  }
+}

--- a/server/views/pages/outside-uk.njk
+++ b/server/views/pages/outside-uk.njk
@@ -1,0 +1,11 @@
+{% extends "../partials/layout.njk" %}
+{% set pageTitle = "Sorry, the service is not available outside of the UK" %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+    <p>You cannot use this service if you are currently outside of the UK.</p>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
We want to restrict access to this service to IP addresses based in the UK. We will use the clients IP address and use a 3rd party service to look up the location, all those accessing outside the UK will see an information page explaining the restriction. 

It has been agreed that if there are issues with reading the IP address or the API service is not responding, then we will allow the user to continue to use the website