### PR TITLE
Implement updated question screens and additional survey response

### DIFF
--- a/integration_tests/e2e/submission/checkin.cy.ts
+++ b/integration_tests/e2e/submission/checkin.cy.ts
@@ -89,26 +89,26 @@ describe('Start Check-in Journey', () => {
 
     cy.url().should('include', '/check-your-answers')
     const checkAnswersPage = SubmissionPage.verifyOnPage(CheckAnswersPage)
-    checkAnswersPage.verifySummaryValue('How are you feeling?', 'OK')
+    checkAnswersPage.verifySummaryValue('How have you been feeling since we last spoke?', 'OK')
     checkAnswersPage.verifySummaryValue(
       'Tell us why you need help with money',
       'I am having trouble with my budgeting.',
     )
     checkAnswersPage.verifySummaryValue('Tell us why you need help with housing', 'I need to find a new place to live.')
     checkAnswersPage.verifySummaryValue(
-      'Is there anything else you need to speak with your probation officer about?',
+      'Would you like us to contact you about anything before your next appointment?',
       'Yes',
     )
     checkAnswersPage.verifySummaryValue(
       'Tell us what you need to talk about',
       'I would like to discuss my upcoming appointment.',
     )
-    checkAnswersPage.clickChangeLink('How are you feeling?')
+    checkAnswersPage.clickChangeLink('How have you been feeling since we last spoke?')
     mentalHealthPage.wellRadio().click()
     mentalHealthPage.continueButton().click()
 
     SubmissionPage.verifyOnPage(CheckAnswersPage)
-    checkAnswersPage.verifySummaryValue('How are you feeling?', 'Well')
+    checkAnswersPage.verifySummaryValue('How have you been feeling since we last spoke?', 'Well')
 
     checkAnswersPage.confirmCheckbox().check()
     checkAnswersPage.completeCheckinButton().click()

--- a/integration_tests/mockApis/esupervisionApi.ts
+++ b/integration_tests/mockApis/esupervisionApi.ts
@@ -87,6 +87,11 @@ export const createMockCheckin = (offender: Offender, overrides: Partial<Checkin
     checkin.surveyResponse = {
       version: '1.0',
       mentalHealth: faker.helpers.arrayElement(Object.values(MentalHealth)),
+      mentalHealthVeryWell: faker.datatype.boolean() ? faker.lorem.sentence() : null,
+      mentalHealthWell: faker.datatype.boolean() ? faker.lorem.sentence() : null,
+      mentalHealthOk: faker.datatype.boolean() ? faker.lorem.sentence() : null,
+      mentalHealthNotGreat: faker.datatype.boolean() ? faker.lorem.sentence() : null,
+      mentalHealthStruggling: faker.datatype.boolean() ? faker.lorem.sentence() : null,
       assistance: faker.helpers.arrayElements(Object.values(SupportAspect)),
       callback: faker.helpers.arrayElement(Object.values(CallbackRequested)),
       mentalHealthSupport: faker.datatype.boolean() ? faker.lorem.sentence() : null,

--- a/integration_tests/pages/submission/callbackPage.ts
+++ b/integration_tests/pages/submission/callbackPage.ts
@@ -3,7 +3,7 @@ import SubmissionPage from './submissionPage'
 
 export default class CallbackPage extends SubmissionPage {
   constructor() {
-    super('Is there anything else you need to speak with your probation officer about?')
+    super('Would you like us to contact you about anything before your next appointment?')
   }
 
   yesRadio = (): PageElement => cy.get('input[name="callback"][value="YES"]')

--- a/integration_tests/pages/submission/mentalHealthPage.ts
+++ b/integration_tests/pages/submission/mentalHealthPage.ts
@@ -2,7 +2,7 @@ import SubmissionPage, { PageElement } from './submissionPage'
 
 export default class MentalHealthPage extends SubmissionPage {
   constructor() {
-    super('How are you feeling?')
+    super('How have you been feeling since we last spoke?')
   }
 
   veryWellRadio = (): PageElement => cy.get('input[name="mentalHealth"][value="VERY_WELL"]')

--- a/server/controllers/submissionController.ts
+++ b/server/controllers/submissionController.ts
@@ -217,6 +217,38 @@ export const handleAssistance: RequestHandler = async (req, res, next) => {
   res.redirect(redirectUrl)
 }
 
+export const handleMentalHealth: RequestHandler = async (req, res, next) => {
+  const { mentalHealth } = req.body
+  const { submissionId } = req.params
+
+  req.session.formData.mentalHealth = mentalHealth
+
+  const mentalHealthFieldsMap: Record<string, string> = {
+    VERY_WELL: 'mentalHealthVeryWell',
+    WELL: 'mentalHealthWell',
+    OK: 'mentalHealthOk',
+    NOT_GREAT: 'mentalHealthNotGreat',
+    STRUGGLING: 'mentalHealthStruggling',
+  }
+
+  for (const [option, fieldName] of Object.entries(mentalHealthFieldsMap)) {
+    if (mentalHealth === option) {
+      req.session.formData[fieldName] = req.body[fieldName]
+    } else {
+      req.session.formData[fieldName] = ''
+    }
+  }
+
+  const basePath = `/submission/${submissionId}`
+  let redirectUrl = `${basePath}/questions/assistance`
+
+  if (req.query.checkAnswers === 'true') {
+    redirectUrl = `${basePath}/check-your-answers`
+  }
+
+  res.redirect(redirectUrl)
+}
+
 export const renderQuestionsCallback: RequestHandler = async (req, res, next) => {
   try {
     res.render('pages/submission/questions/callback', pageParams(req))
@@ -236,6 +268,11 @@ export const renderCheckAnswers: RequestHandler = async (req, res, next) => {
 export const handleSubmission: RequestHandler = async (req, res: Response<object, SubmissionLocals>, next) => {
   const {
     mentalHealth,
+    mentalHealthVeryWell,
+    mentalHealthWell,
+    mentalHealthOk,
+    mentalHealthNotGreat,
+    mentalHealthStruggling,
     mentalHealthSupport,
     alcoholSupport,
     drugsSupport,
@@ -272,6 +309,11 @@ export const handleSubmission: RequestHandler = async (req, res: Response<object
     survey: {
       version: '2025-07-10@pilot',
       mentalHealth: mentalHealth as MentalHealth,
+      mentalHealthVeryWell: mentalHealthVeryWell as string,
+      mentalHealthWell: mentalHealthWell as string,
+      mentalHealthOk: mentalHealthOk as string,
+      mentalHealthNotGreat: mentalHealthNotGreat as string,
+      mentalHealthStruggling: mentalHealthStruggling as string,
       assistance: assistance as SupportAspect[],
       mentalHealthSupport: mentalHealthSupport as string,
       alcoholSupport: alcoholSupport as string,

--- a/server/data/models/survey/surveyResponse.ts
+++ b/server/data/models/survey/surveyResponse.ts
@@ -28,6 +28,16 @@ export default class SurveyResponse implements Versioned {
 
   mentalHealth: MentalHealth
 
+  mentalHealthVeryWell: string
+
+  mentalHealthWell: string
+
+  mentalHealthOk: string
+
+  mentalHealthNotGreat: string
+
+  mentalHealthStruggling: string
+
   assistance: SupportAspect[]
 
   mentalHealthSupport: string

--- a/server/routes/submissionRoutes.ts
+++ b/server/routes/submissionRoutes.ts
@@ -19,6 +19,7 @@ import {
   renderVideoRecord,
   renderViewVideo,
   handleAssistance,
+  handleMentalHealth,
 } from '../controllers/submissionController'
 
 import {
@@ -83,8 +84,7 @@ export default function routes({ esupervisionService }: Services): Router {
   router.post('/verify', validateFormData(personalDetailsSchema), handleVerify)
 
   get('/questions/mental-health', protectSubmission, renderQuestionsMentalHealth)
-  router.post('/questions/mental-health', validateFormData(mentalHealthSchema), handleRedirect('/questions/assistance'))
-
+  router.post('/questions/mental-health', protectSubmission, validateFormData(mentalHealthSchema), handleMentalHealth)
   get('/questions/assistance', protectSubmission, renderAssistance)
   router.post('/questions/assistance', protectSubmission, validateFormData(assistanceSchema), handleAssistance)
 

--- a/server/schemas/submissionSchemas.ts
+++ b/server/schemas/submissionSchemas.ts
@@ -36,6 +36,11 @@ const MentalHealthEnum = z
 
 export const mentalHealthSchema = z.object({
   mentalHealth: MentalHealthEnum,
+  mentalHealthVeryWell: z.string().optional(),
+  mentalHealthWell: z.string().optional(),
+  mentalHealthOk: z.string().optional(),
+  mentalHealthNotGreat: z.string().optional(),
+  mentalHealthStruggling: z.string().optional(),
 })
 
 export const assistanceSchema = z.object({

--- a/server/views/pages/submission/check-answers.njk
+++ b/server/views/pages/submission/check-answers.njk
@@ -27,7 +27,7 @@
 
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">How are you feeling?</dt>
+          <dt class="govuk-summary-list__key">How have you been feeling since we last spoke?</dt>
           <dd class="govuk-summary-list__value">{{ formData['mentalHealth'] | userFriendlyString }}</dd>
           <dd class="govuk-summary-list__actions">
             <a class="govuk-link" href="/submission/{{ submissionId }}/questions/mental-health?checkAnswers=true"
@@ -35,6 +35,66 @@
             >
           </dd>
         </div>
+        {% if formData['mentalHealthVeryWell'] %}
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Tell us why you are very well</dt>
+            <dd class="govuk-summary-list__value">{{ formData['mentalHealthVeryWell'] }}</dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="/submission//{{ submissionId }}/questions/mental-health?checkAnswers=true">
+                Change<span class="govuk-visually-hidden"> answer for tell us why you are very well</span>
+              </a>
+            </dd>
+          </div>
+        {% endif %}
+
+        {% if formData['mentalHealthWell'] %}
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Tell us why you are well</dt>
+            <dd class="govuk-summary-list__value">{{ formData['mentalHealthWell'] }}</dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="/submission/{{ submissionId }}/questions/mental-health?checkAnswers=true">
+                Change<span class="govuk-visually-hidden"> answer for tell us why you are well</span>
+              </a>
+            </dd>
+          </div>
+        {% endif %}
+
+        {% if formData['mentalHealthOk'] %}
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Tell us why you are OK</dt>
+            <dd class="govuk-summary-list__value">{{ formData['mentalHealthOk'] }}</dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="/submission/{{ submissionId }}/questions/mental-health?checkAnswers=true">
+                Change<span class="govuk-visually-hidden"> answer for tell us why you are OK</span>
+              </a>
+            </dd>
+          </div>
+        {% endif %}
+
+        {% if formData['mentalHealthNotGreat'] %}
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Tell us why you are not great</dt>
+            <dd class="govuk-summary-list__value">{{ formData['mentalHealthNotGreat'] }}</dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="/submission/{{ submissionId }}/questions/mental-health?checkAnswers=true">
+                Change<span class="govuk-visually-hidden"> answer for tell us why you are not great</span>
+              </a>
+            </dd>
+          </div>
+        {% endif %}
+
+        {% if formData['mentalHealthStruggling'] %}
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Tell us more about struggling</dt>
+            <dd class="govuk-summary-list__value">{{ formData['mentalHealthStruggling'] }}</dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="/submission/{{ submissionId }}/questions/mental-health?checkAnswers=true">
+                Change<span class="govuk-visually-hidden"> answer for tell us more about struggling</span>
+              </a>
+            </dd>
+          </div>
+        {% endif %}
+        
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Is there anything you need support with or want to let us know about?</dt>
           <dd class="govuk-summary-list__value">
@@ -136,13 +196,13 @@
 
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            Is there anything else you need to speak with your probation officer about?
+            Would you like us to contact you about anything before your next appointment?
           </dt>
           <dd class="govuk-summary-list__value">{{ formData['callback'] | userFriendlyString }}</dd>
           <dd class="govuk-summary-list__actions">
             <a class="govuk-link" href="/submission/{{ submissionId }}/questions/callback?checkAnswers=true"
               >Change<span class="govuk-visually-hidden">
-                answer for is there anything else you need to speak with your probation officer about</span
+                answer for Would you like us to contact you about anything before your next appointment</span
               ></a
             >
           </dd>

--- a/server/views/pages/submission/questions/callback.njk
+++ b/server/views/pages/submission/questions/callback.njk
@@ -6,7 +6,7 @@
 {% from "../../../partials/errorSummary.njk" import errorSummary %}
 {% extends "../../../partials/layout.njk" %}
 
-{% set title = "Is there anything else you need to speak with your probation officer about?" %}
+{% set title = "Would you like us to contact you about anything before your next appointment?" %}
 {% set pageTitle = title %}
 
 {% block beforeContent %}
@@ -32,7 +32,7 @@
             errorMessage: validationErrors | findError("callbackDetails"),
             value: formData["callbackDetails"],
             label: {
-              text: "Tell us what you need to talk about (optional)"
+              text: "Tell us what you need to talk about, for example, something you're struggling with or need more information about (optional)"
             }
           })
         }}
@@ -47,7 +47,7 @@
               errorMessage: validationErrors | findError("callback"),
               value: formData["callback"],
               hint: {
-                text: "There may be a delay in your probation officer contacting you. They may refer you to support services if you have asked for help. "
+                text: "This could be something you've already asked for help with or something new."
               },
               fieldset: {
                 legend: {

--- a/server/views/pages/submission/questions/mental-health.njk
+++ b/server/views/pages/submission/questions/mental-health.njk
@@ -2,10 +2,11 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "../../../partials/errorSummary.njk" import errorSummary %}
 {% extends "../../../partials/layout.njk" %}
 
-{% set pageTitle = "How are you feeling?" %}
+{% set pageTitle = "How have you been feeling since we last spoke?" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
@@ -21,7 +22,55 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {{ errorSummary(validationErrors) }}
+      {% set veryWellHtml %}
+        {{ govukTextarea({
+          name: "mentalHealthVeryWell",
+          id: "mentalHealthVeryWell",
+          label: { text: "Tell us why you are very well (optional)" },
+          value: formData["mentalHealthVeryWell"],
+          errorMessage: validationErrors | findError("mentalHealthVeryWell")
+        }) }}
+      {% endset -%}
 
+      {% set wellHtml %}
+        {{ govukTextarea({
+          name: "mentalHealthWell",
+          id: "mentalHealthWell",
+          label: { text: "Tell us why you are well (optional)" },
+          value: formData["mentalHealthWell"],
+          errorMessage: validationErrors | findError("mentalHealthWell")
+        }) }}
+      {% endset -%}
+
+      {% set okHtml %}
+        {{ govukTextarea({
+          name: "mentalHealthOk",
+          id: "mentalHealthOk",
+          label: { text: "Tell us why you are OK (optional)" },
+          value: formData["mentalHealthOk"],
+          errorMessage: validationErrors | findError("mentalHealthOk")
+        }) }}
+      {% endset -%}
+
+      {% set notGreatHtml %}
+        {{ govukTextarea({
+          name: "mentalHealthNotGreat",
+          id: "mentalHealthNotGreat",
+          label: { text: "Tell us why you are not great (optional)" },
+          value: formData["mentalHealthNotGreat"],
+          errorMessage: validationErrors | findError("mentalHealthNotGreat")
+        }) }}
+      {% endset -%}
+
+      {% set strugglingHtml %}
+        {{ govukTextarea({
+          name: "mentalHealthStruggling",
+          id: "mentalHealthStruggling",
+          label: { text: "Tell us why you are struggling (optional)" },
+          value: formData["mentalHealthStruggling"],
+          errorMessage: validationErrors | findError("mentalHealthStruggling")
+        }) }}
+      {% endset -%}
       <form method="POST">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
@@ -31,7 +80,7 @@
           errorMessage: validationErrors | findError("mentalHealth"),
           value: formData["mentalHealth"],
           hint: {
-            text: "Think about things like if you have noticed a change in your mood and what may have caused this. "
+            text: "Think about things like if you have noticed a change in your mood and what may have caused this."
           },
           fieldset: {
           legend: {
@@ -43,23 +92,38 @@
           items: [
               {
                 value: "VERY_WELL",
-                text: "Very well"
+                text: "Very well",
+                conditional: {
+                  html: veryWellHtml
+                }
               },
               {
                 value: "WELL",
-                text: "Well"
+                text: "Well",
+                conditional: {
+                  html: wellHtml
+                }
               },
               {
                 value: "OK",
-                text: "OK"
+                text: "OK",
+                conditional: {
+                  html: okHtml
+                }
               },
               {
                 value: "NOT_GREAT",
-                text: "Not great"
+                text: "Not great",
+                conditional: {
+                  html: notGreatHtml
+                }
               },
               {
                 value: "STRUGGLING",
-                text: "Struggling"
+                text: "Struggling",
+                conditional: {
+                  html: strugglingHtml
+                }
               }
             ]
           })

--- a/server/views/pages/submission/questions/mental-health.njk
+++ b/server/views/pages/submission/questions/mental-health.njk
@@ -31,11 +31,11 @@
           errorMessage: validationErrors | findError("mentalHealth"),
           value: formData["mentalHealth"],
           hint: {
-            text: "Think about things like if you have noticed a change in your mood. "
+            text: "Think about things like if you have noticed a change in your mood and what may have caused this. "
           },
           fieldset: {
           legend: {
-          text: "How are you feeling?",
+          text: "How have you been feeling since we last spoke?",
           isPageHeading: true,
           classes: "govuk-fieldset__legend--l"
           }


### PR DESCRIPTION
[ESUP-1005](https://dsdmoj.atlassian.net/browse/ESUP-1005)

This PR adds new fields to the survey response as well as some content changes.
We now send a text field with the mental health check, so if a user clicks 'Very well', they are asked to elaborate on why they feel that way.

Keeping in draft for now because if we want this to show on the PP side, we will need to make some changes to other screens and by doing that we'll need to update the V1 endpoints. Not a priority I believe, but as we're dual processing I thought it'd be best to keep this here just in case

[ESUP-1005]: https://dsdmoj.atlassian.net/browse/ESUP-1005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ