### PR TITLE
feat(ESUP-1109): Added v2 feedback as env var and passing it as prop to pages

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,6 +17,7 @@ generic-service:
     HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
     ESUPERVISION_API_URL: 'https://esupervision-api-dev.hmpps.service.justice.gov.uk'
+    V2_FEEDBACK_URL: 'https://probation-check-in-dev.hmpps.service.justice.gov.uk/feedback'
     ENVIRONMENT_NAME: DEV
     AUDIT_ENABLED: 'false'
     AUTHORISED_USER_ROLES: 'ROLE_ESUPERVISION__PRACTITIONER__RW'

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -13,6 +13,7 @@ generic-service:
     HMPPS_AUTH_URL: 'https://sign-in-preprod.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-preprod.prison.service.justice.gov.uk'
     ESUPERVISION_API_URL: 'https://esupervision-api-preprod.hmpps.service.justice.gov.uk'
+    V2_FEEDBACK_URL: 'https://probation-check-in-preprod.hmpps.service.justice.gov.uk/feedback'
     ENVIRONMENT_NAME: PRE-PRODUCTION
     AUDIT_ENABLED: 'false'
 

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,6 +11,7 @@ generic-service:
     HMPPS_AUTH_URL: 'https://sign-in.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api.prison.service.justice.gov.uk'
     ESUPERVISION_API_URL: 'https://esupervision-api.hmpps.service.justice.gov.uk'
+    V2_FEEDBACK_URL: 'https://probation-check-in.hmpps.service.justice.gov.uk/feedback'
     AUDIT_ENABLED: 'false'
     AUTHORISED_USER_ROLES: 'ROLE_ESUPERVISION__PRACTITIONER__RW'
 

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -13,6 +13,7 @@ generic-service:
     HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
     ESUPERVISION_API_URL: 'https://esupervision-api-test.hmpps.service.justice.gov.uk'
+    V2_FEEDBACK_URL: 'https://probation-check-in-test.hmpps.service.justice.gov.uk/feedback'
     ENVIRONMENT_NAME: TEST
     AUDIT_ENABLED: 'false'
     AUTHORISED_USER_ROLES: 'ROLE_ESUPERVISION__PRACTITIONER__RW'

--- a/server/config.ts
+++ b/server/config.ts
@@ -93,6 +93,13 @@ export default {
       agent: new AgentConfig(Number(get('EXAMPLE_API_TIMEOUT_RESPONSE', 5000))),
     },
   },
+  v2: {
+    feedbackUrl: get(
+      'V2_FEEDBACK_URL',
+      'https://probation-check-in-dev.hmpps.service.justice.gov.uk/feedback',
+      requiredInProduction,
+    ),
+  },
   sqs: {
     audit: auditConfig(),
   },

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -21,7 +21,7 @@ export default function nunjucksSetup(app: express.Express): void {
   app.locals.serviceName = 'Check in with your probation officer'
   app.locals.serviceNamePractitioner = 'Manage probation check ins'
   app.locals.supportEmailAddress = 'checkinwithprobation@justice.gov.uk'
-
+  app.locals.feedbackUrl = config.v2.feedbackUrl
   app.locals.environmentName = config.environmentName
   app.locals.environmentNameColour = config.environmentName === 'PRE-PRODUCTION' ? 'govuk-tag--green' : ''
   let assetManifest: Record<string, string> = {}

--- a/server/views/pages/practitioners/layout.njk
+++ b/server/views/pages/practitioners/layout.njk
@@ -107,7 +107,7 @@
           class="govuk-link govuk-link--no-visited-state"
           target="_blank"
           rel="nofollow"
-          href="https://forms.office.com/pages/responsepage.aspx?id=KEeHxuZx_kGp4S6MNndq2GF5fsslU5tImfiqSSPf6JhUQ0I3WUFTR1lVOUVSRjBRNElMSlYwMkRZWiQlQCN0PWcu&route=shorturl"
+          href="{{ feedbackUrl }}"
           >feedback (opens in a new tab)</a
         >
         will help us to improve it.

--- a/server/views/pages/submission/confirmation.njk
+++ b/server/views/pages/submission/confirmation.njk
@@ -21,7 +21,7 @@
       <p>We will remind you when it is time for your next check in.</p>
       <p>
         <a
-          href="https://forms.office.com/pages/responsepage.aspx?id=KEeHxuZx_kGp4S6MNndq2GF5fsslU5tImfiqSSPf6JhUQko3QVg0MkVGRTVYV0dFMEJJUzBZUTIyVCQlQCN0PWcu&route=shorturl"
+          href="{{ feedbackUrl }}"
           target="_blank"
           class="govuk-link govuk-link--no-visited-state"
           rel="noopener noreferrer"

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -23,12 +23,18 @@
       serviceName: serviceName
     })
   }}
+  {% set feedbackLink %}
+    <a class="govuk-link govuk-link--no-visited-state" target="_blank" rel="nofollow" href="{{ feedbackUrl }}">
+      feedback (opens in a new tab)
+    </a>
+  {% endset %}
+
   {{
     govukPhaseBanner({
-    tag: {
-      text: "Private Beta"
-    },
-    html: 'This is a new service – your <a class="govuk-link govuk-link--no-visited-state" target="_blank" rel="nofollow" href="https://forms.office.com/pages/responsepage.aspx?id=KEeHxuZx_kGp4S6MNndq2GF5fsslU5tImfiqSSPf6JhUQko3QVg0MkVGRTVYV0dFMEJJUzBZUTIyVCQlQCN0PWcu&route=shorturl">feedback (opens in a new tab)</a> will help us to improve it.'
+      tag: {
+        text: "Private Beta"
+      },
+      html: 'This is a new service – your ' + feedbackLink + ' will help us to improve it.'
     })
   }}
 {% endblock %}


### PR DESCRIPTION
We need to redirect people to the correct feedback form, which lives in V2 UI. This PR achieves that by setting the URLs as env vars and passing them in as props to the pages which need it.