### PR TITLE
add '/resolve' endpoint to proxy check in images/videos

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -17,6 +17,7 @@ import routes from './routes'
 import statisticsRoutes from './routes/statisticsRoutes'
 import submissionRoutes from './routes/submissionRoutes'
 import v2statisticsRoutes from './routes/v2statisticsRoutes'
+import checkinRoutes from './routes/resolveUrlRoutes'
 import practitionersRoutes from './routes/practitionersRoutes'
 import featureFlags from './middleware/featureFlags'
 
@@ -58,6 +59,7 @@ export default function createApp(services: Services): express.Application {
   app.use('/submission/:submissionId', submissionRoutes(services))
   app.use('/statistics', statisticsRoutes())
   app.use('/v2statistics', v2statisticsRoutes())
+  app.use('/resolve', checkinRoutes())
   app.use('/practitioners', practitionersRoutes())
   app.use('/practitioners', (req, res) => {
     res.status(404).render('pages/practitioners/not-found')

--- a/server/controllers/urlResolverController.ts
+++ b/server/controllers/urlResolverController.ts
@@ -1,0 +1,30 @@
+import { RequestHandler } from 'express'
+import { services } from '../services'
+import MediaUrlType from '../data/models/mediaUrlType'
+
+const { esupervisionService } = services()
+
+const entityToMediaTypeMapping = new Map<string, MediaUrlType>([
+  ['checkin|video', MediaUrlType.CheckinVideo],
+  ['checkin|snapshot', MediaUrlType.CheckinSnapshot],
+  ['offender|photo', MediaUrlType.OffenderReferencePhoto],
+])
+
+const resolveUrl: RequestHandler = async (req, res, next) => {
+  try {
+    const { entityType, attribute, uuid } = req.params
+    const snapshotIndex = req.query.snapshotIndex ? parseInt(req.query.snapshotIndex as string, 10) : 0
+    const mediaType = entityToMediaTypeMapping.get(`${entityType}|${attribute}`)
+    if (mediaType === undefined) {
+      res.status(400).send(`Invalid entity='${entityType}' or attribute='${attribute}`)
+      return
+    }
+
+    const url = await esupervisionService.resolveUrl(mediaType, uuid, { snapshotIndex })
+    res.redirect(url)
+  } catch (error) {
+    next(error)
+  }
+}
+
+export default resolveUrl

--- a/server/data/esupervisionApiClient.ts
+++ b/server/data/esupervisionApiClient.ts
@@ -23,6 +23,7 @@ import Stats from './models/stats'
 import OffenderInfoByContact from './models/offenderInfoByContact'
 import { CheckinEventType } from './models/checkinEvent'
 import { V2StatsResponse } from './models/v2stats'
+import MediaUrlType from './models/mediaUrlType'
 
 /**
  * Specifies content types for possible upload locations for a checkin.
@@ -302,6 +303,50 @@ export default class EsupervisionApiClient extends RestClient {
       },
       asSystem(),
     )
+  }
+
+  async resolveUrl(
+    urlType: MediaUrlType,
+    uuid: string,
+    { snapshotIndex = 0 }: { snapshotIndex?: number },
+  ): Promise<string> {
+    type ProxiedUrl = { url: string }
+    let response: ProxiedUrl | null = null
+
+    switch (urlType) {
+      case MediaUrlType.CheckinSnapshot:
+        response = await this.get<ProxiedUrl>(
+          {
+            path: `/v2/offender_checkins/${uuid}/proxy/snapshot`,
+            query: { index: snapshotIndex },
+          },
+          asSystem(),
+        )
+        break
+      case MediaUrlType.CheckinVideo:
+        response = await this.get<ProxiedUrl>(
+          {
+            path: `/v2/offender_checkins/${uuid}/proxy/video`,
+          },
+          asSystem(),
+        )
+        break
+      case MediaUrlType.OffenderReferencePhoto:
+        response = await this.get<ProxiedUrl>(
+          {
+            path: `/v2/offenders/${uuid}/proxy/photo`,
+          },
+          asSystem(),
+        )
+        break
+      default:
+        throw Error(`Unhandled media type: ${urlType}`)
+    }
+
+    if (!response) {
+      throw new Error(`Failed to resolve URL for ${urlType} with UUID ${uuid}`)
+    }
+    return response.url
   }
 
   async getCheckinStats(): Promise<Stats> {

--- a/server/data/models/mediaUrlType.ts
+++ b/server/data/models/mediaUrlType.ts
@@ -1,0 +1,10 @@
+/**
+ * What URLs can be proxied by the API
+ */
+enum MediaUrlType {
+  CheckinVideo,
+  CheckinSnapshot,
+  OffenderReferencePhoto,
+}
+
+export default MediaUrlType

--- a/server/routes/resolveUrlRoutes.ts
+++ b/server/routes/resolveUrlRoutes.ts
@@ -1,0 +1,31 @@
+import { RequestHandler, Router } from 'express'
+import { VerificationClient, AuthenticatedRequest } from '@ministryofjustice/hmpps-auth-clients'
+import config from '../config'
+import logger from '../../logger'
+import authorisationMiddleware from '../middleware/authorisationMiddleware'
+import setUpCurrentUser from '../middleware/setUpCurrentUser'
+import asyncMiddleware from '../middleware/asyncMiddleware'
+import resolveUrl from '../controllers/urlResolverController'
+
+export default function routes(): Router {
+  const router = Router()
+
+  // practitioner routes all require a login
+  const tokenVerificationClient = new VerificationClient(config.apis.tokenVerification, logger)
+  router.use(async (req, res, next) => {
+    if (req.isAuthenticated() && (await tokenVerificationClient.verifyToken(req as unknown as AuthenticatedRequest))) {
+      return next()
+    }
+    req.session.returnTo = req.originalUrl
+    return res.redirect('/sign-in')
+  })
+
+  router.use(authorisationMiddleware(config.authorisedUserRoles))
+  router.use(setUpCurrentUser())
+
+  const get = (routePath: string | string[], handler: RequestHandler) => router.get(routePath, asyncMiddleware(handler))
+
+  get('/:entityType/:uuid/:attribute', resolveUrl)
+
+  return router
+}

--- a/server/services/esupervisionService.ts
+++ b/server/services/esupervisionService.ts
@@ -18,6 +18,7 @@ import Stats from '../data/models/stats'
 import OffenderInfoByContact from '../data/models/offenderInfoByContact'
 import { CheckinEventType } from '../data/models/checkinEvent'
 import { V2StatsResponse } from '../data/models/v2stats'
+import MediaUrlType from '../data/models/mediaUrlType'
 
 export default class EsupervisionService {
   constructor(private readonly esupervisionApiClient: EsupervisionApiClient) {}
@@ -110,6 +111,10 @@ export default class EsupervisionService {
 
   getOffenderCountByPractitioner(): Promise<PractitionerStats[]> {
     return this.esupervisionApiClient.getOffenderCountByPractitioner()
+  }
+
+  resolveUrl(urlType: MediaUrlType, uuid: string, { snapshotIndex = 0 }: { snapshotIndex?: number }): Promise<string> {
+    return this.esupervisionApiClient.resolveUrl(urlType, uuid, { snapshotIndex })
   }
 
   getCheckinStats(): Promise<Stats> {


### PR DESCRIPTION
Adds a endpoints to proxy check in related media: 

```
/resolve/checkin/:uuid/snapshot
/resolve/checkin/:uuid/video
/resolve/offender/:uuid/photo
```