### PR TITLE
Add role restriction for /invite-pop routes in dev

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -22,6 +22,7 @@ generic-service:
     ENVIRONMENT_NAME: DEV
     AUDIT_ENABLED: 'false'
     AUTHORISED_USER_ROLES: 'ROLE_ESUPERVISION__PRACTITIONER__RW'
+    INVITE_POP_USER_ROLES: 'ROLE_ESUPERVISION__PRACTITIONER__INVITE_POP'
 
 generic-prometheus-alerts:
   alertSeverity: hmpps_esupervision_alerts_nonprod


### PR DESCRIPTION
Restrict access to the `/inivte-pop` routes to users with the `ROLE_ESUPERVISION__PRACTITIONER__INVITE_POP` role