### PR TITLE
send practioner username in  registration invite request

### DIFF
--- a/server/controllers/invitePopController.ts
+++ b/server/controllers/invitePopController.ts
@@ -122,6 +122,7 @@ export const handleInviteSubmit: RequestHandler = async (req, res, next) => {
       crn,
       email: contactPreference === 'EMAIL' ? email : undefined,
       mobile: contactPreference === 'TEXT' ? mobile : undefined,
+      createdByUsername: req.user.username,
     })
 
     sendAuditEvent('POP_ACCOUNT_INVITE_SENT', req.user.username, crn)

--- a/server/data/popApiClient.ts
+++ b/server/data/popApiClient.ts
@@ -7,6 +7,7 @@ export type RegistrationInviteRequest = {
   personReference: string
   email?: string
   mobileNumber?: string
+  createdByUsername: string
 }
 
 export default class PopApiClient extends RestClient {

--- a/server/services/popService.ts
+++ b/server/services/popService.ts
@@ -4,16 +4,18 @@ export type InvitePopInput = {
   crn: string
   email?: string
   mobile?: string
+  createdByUsername: string
 }
 
 export default class PopService {
   constructor(private readonly popApiClient: PopApiClient) {}
 
-  invitePop({ crn, email, mobile }: InvitePopInput): Promise<void> {
+  invitePop({ crn, email, mobile, createdByUsername }: InvitePopInput): Promise<void> {
     return this.popApiClient.createRegistrationInvite({
       personReference: crn,
       email,
       mobileNumber: mobile,
+      createdByUsername,
     })
   }
 }


### PR DESCRIPTION
- Adds a createdByUsername field to the PoP registration invite request, populated with the logged-in practitioner's username (req.user.username)
- Threads the field through handleInviteSubmit → PopService.invitePop → PopApiClient.createRegistrationInvite → POST /v1/registration-invites